### PR TITLE
Visualizer for pzarr files

### DIFF
--- a/ingest/foxglove/review_mcap.json
+++ b/ingest/foxglove/review_mcap.json
@@ -1,0 +1,186 @@
+{
+  "configById": {
+    "Image!3zkla5f": {
+      "cameraState": {
+        "distance": 20,
+        "perspective": true,
+        "phi": 60,
+        "target": [
+          0,
+          0,
+          0
+        ],
+        "targetOffset": [
+          0,
+          0,
+          0
+        ],
+        "targetOrientation": [
+          0,
+          0,
+          0,
+          1
+        ],
+        "thetaOffset": 60,
+        "fovy": 45,
+        "near": 0.5,
+        "far": 5000
+      },
+      "followMode": "follow-pose",
+      "scene": {},
+      "transforms": {},
+      "topics": {},
+      "layers": {},
+      "publish": {
+        "type": "point",
+        "poseTopic": "/move_base_simple/goal",
+        "pointTopic": "/clicked_point",
+        "poseEstimateTopic": "/initialpose",
+        "poseEstimateXDeviation": 0.5,
+        "poseEstimateYDeviation": 0.5,
+        "poseEstimateThetaDeviation": 0.26179939
+      },
+      "synchronize": false,
+      "imageMode": {
+        "imageTopic": "/finger/image"
+      }
+    },
+    "Image!2r5557g": {
+      "cameraState": {
+        "distance": 20,
+        "perspective": true,
+        "phi": 60,
+        "target": [
+          0,
+          0,
+          0
+        ],
+        "targetOffset": [
+          0,
+          0,
+          0
+        ],
+        "targetOrientation": [
+          0,
+          0,
+          0,
+          1
+        ],
+        "thetaOffset": 60,
+        "fovy": 45,
+        "near": 0.5,
+        "far": 5000
+      },
+      "followMode": "follow-pose",
+      "scene": {},
+      "transforms": {},
+      "topics": {},
+      "layers": {},
+      "publish": {
+        "type": "point",
+        "poseTopic": "/move_base_simple/goal",
+        "pointTopic": "/clicked_point",
+        "poseEstimateTopic": "/initialpose",
+        "poseEstimateXDeviation": 0.5,
+        "poseEstimateYDeviation": 0.5,
+        "poseEstimateThetaDeviation": 0.26179939
+      },
+      "synchronize": false,
+      "imageMode": {
+        "imageTopic": "/gopro/image"
+      }
+    },
+    "Plot!3ahq65t": {
+      "xAxisLabel": "",
+      "foxglovePanelTitle": "Linear Accel",
+      "paths": [
+        {
+          "timestampMethod": "receiveTime",
+          "value": "/gopro/accel.linear_acceleration.x",
+          "enabled": true,
+          "color": "#4e98e2",
+          "id": "06c76180-5e97-4141-9891-a39f0b7c4457",
+          "label": "a_x"
+        },
+        {
+          "timestampMethod": "receiveTime",
+          "value": "/gopro/accel.linear_acceleration.y",
+          "enabled": true,
+          "color": "#f5774d",
+          "id": "00912f57-58af-4d8c-837b-234209c744a4",
+          "label": "a_y"
+        },
+        {
+          "timestampMethod": "receiveTime",
+          "value": "/gopro/accel.linear_acceleration.z",
+          "enabled": true,
+          "color": "#2cff00",
+          "id": "68fd08fe-7862-40dd-a2b9-e0731a3f6f75",
+          "label": "a_z"
+        }
+      ],
+      "yAxisLabel": "m/s^2"
+    },
+    "Audio!1v0aezy": {
+      "volume": 0.8731,
+      "slidingViewWidth": 10,
+      "topic": "/audio"
+    },
+    "Plot!35segx7": {
+      "foxglovePanelTitle": "Gyro",
+      "paths": [
+        {
+          "timestampMethod": "receiveTime",
+          "value": "/gopro/gyro.angular_velocity.x",
+          "enabled": true,
+          "color": "#4e98e2",
+          "id": "2301c2b4-5e13-4885-88b0-35e034923f5b",
+          "label": "w_x"
+        },
+        {
+          "timestampMethod": "receiveTime",
+          "value": "/gopro/gyro.angular_velocity.y",
+          "enabled": true,
+          "color": "#f5774d",
+          "id": "30bc5f80-395d-4ee8-a0aa-1f863a9d3e0f",
+          "label": "w_y"
+        },
+        {
+          "timestampMethod": "receiveTime",
+          "value": "/gopro/gyro.angular_velocity.z",
+          "enabled": true,
+          "color": "#2cff00",
+          "id": "1fc81e24-484c-4edd-a0fe-878e3ce2c66f",
+          "label": "w_z"
+        }
+      ]
+    }
+  },
+  "globalVariables": {},
+  "userNodes": {},
+  "playbackConfig": {
+    "speed": 1
+  },
+  "drawerConfig": {
+    "tracks": []
+  },
+  "layout": {
+    "first": {
+      "first": "Image!3zkla5f",
+      "second": "Image!2r5557g",
+      "direction": "row"
+    },
+    "second": {
+      "first": {
+        "first": "Plot!3ahq65t",
+        "second": "Plot!35segx7",
+        "direction": "row"
+      },
+      "second": "Audio!1v0aezy",
+      "direction": "column",
+      "splitPercentage": 62.12871287128712
+    },
+    "direction": "column",
+    "splitPercentage": 56.229685807150595
+  }
+}

--- a/ingest/foxglove/review_mcap.json
+++ b/ingest/foxglove/review_mcap.json
@@ -45,7 +45,7 @@
         "imageTopic": "/finger/image"
       }
     },
-    "Image!2r5557g": {
+    "Image!24wk5v": {
       "cameraState": {
         "distance": 20,
         "perspective": true,
@@ -121,11 +121,6 @@
       ],
       "yAxisLabel": "m/s^2"
     },
-    "Audio!1v0aezy": {
-      "volume": 0.8731,
-      "slidingViewWidth": 10,
-      "topic": "/audio"
-    },
     "Plot!35segx7": {
       "foxglovePanelTitle": "Gyro",
       "paths": [
@@ -154,6 +149,18 @@
           "label": "w_z"
         }
       ]
+    },
+    "Audio!3nxj4f9": {
+      "volume": 1,
+      "slidingViewWidth": 10,
+      "topic": "/gopro/audio",
+      "muted": true
+    },
+    "Audio!1v0aezy": {
+      "volume": 0.8731,
+      "slidingViewWidth": 10,
+      "topic": "/finger/audio",
+      "muted": false
     }
   },
   "globalVariables": {},
@@ -167,7 +174,7 @@
   "layout": {
     "first": {
       "first": "Image!3zkla5f",
-      "second": "Image!2r5557g",
+      "second": "Image!24wk5v",
       "direction": "row"
     },
     "second": {
@@ -176,11 +183,15 @@
         "second": "Plot!35segx7",
         "direction": "row"
       },
-      "second": "Audio!1v0aezy",
+      "second": {
+        "first": "Audio!3nxj4f9",
+        "second": "Audio!1v0aezy",
+        "direction": "column"
+      },
       "direction": "column",
-      "splitPercentage": 62.12871287128712
+      "splitPercentage": 45.663662052045886
     },
     "direction": "column",
-    "splitPercentage": 56.229685807150595
+    "splitPercentage": 51.65929203539823
   }
 }

--- a/ingest/polyumi_ingest/export/__init__.py
+++ b/ingest/polyumi_ingest/export/__init__.py
@@ -1,0 +1,5 @@
+"""Export utilities for pzarr working-format stores."""
+
+from polyumi_ingest.export.mcap import export_scene_to_mcap
+
+__all__ = ['export_scene_to_mcap']

--- a/ingest/polyumi_ingest/export/helpers.py
+++ b/ingest/polyumi_ingest/export/helpers.py
@@ -1,0 +1,26 @@
+"""Shared helpers for pzarr export functions."""
+
+from concurrent.futures import ThreadPoolExecutor
+
+import cv2
+import numpy as np
+
+
+def jpegxl_to_jpeg(frame: np.ndarray, quality: int) -> bytes:
+    """Re-encode a (H, W, 3) uint8 RGB frame from pzarr JpegXL storage to JPEG bytes."""
+    bgr = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
+    ok, buf = cv2.imencode('.jpg', bgr, [cv2.IMWRITE_JPEG_QUALITY, quality])
+    if not ok:
+        raise RuntimeError('cv2.imencode failed')
+    return buf.tobytes()
+
+
+def encode_frames_to_jpeg(frames: np.ndarray, quality: int) -> list[bytes]:
+    """
+    Parallel JPEG re-encoding for a batch of RGB frames decoded from pzarr JpegXL storage.
+
+    frames: (N, H, W, 3) uint8 RGB.
+    Returns N JPEG byte strings in frame order.
+    """
+    with ThreadPoolExecutor() as pool:
+        return list(pool.map(lambda f: jpegxl_to_jpeg(f, quality), frames))

--- a/ingest/polyumi_ingest/export/helpers.py
+++ b/ingest/polyumi_ingest/export/helpers.py
@@ -15,12 +15,11 @@ def jpegxl_to_jpeg(frame: np.ndarray, quality: int) -> bytes:
     return buf.tobytes()
 
 
-def encode_frames_to_jpeg(frames: np.ndarray, quality: int) -> list[bytes]:
+def encode_frames_to_jpeg(frames: np.ndarray, quality: int, executor: ThreadPoolExecutor) -> list[bytes]:
     """
     Parallel JPEG re-encoding for a batch of RGB frames decoded from pzarr JpegXL storage.
 
     frames: (N, H, W, 3) uint8 RGB.
     Returns N JPEG byte strings in frame order.
     """
-    with ThreadPoolExecutor() as pool:
-        return list(pool.map(lambda f: jpegxl_to_jpeg(f, quality), frames))
+    return list(executor.map(lambda f: jpegxl_to_jpeg(f, quality), frames))

--- a/ingest/polyumi_ingest/export/mcap.py
+++ b/ingest/polyumi_ingest/export/mcap.py
@@ -149,6 +149,7 @@ def _register_channels(
     has_accel: bool,
     has_gyro: bool,
     has_gps: bool,
+    has_gopro_audio: bool,
 ) -> dict[str, int]:
     """Register all schemas and channels; return {topic: channel_id}."""
     img_sid = writer.register_schema('foxglove.CompressedImage', 'jsonschema', _SCHEMA_COMPRESSED_IMAGE)
@@ -161,10 +162,12 @@ def _register_channels(
 
     channels: dict[str, int] = {
         '/finger/image': ch('/finger/image', img_sid),
-        '/audio': ch('/audio', aud_sid),
+        '/finger/audio': ch('/finger/audio', aud_sid),
     }
     if has_gopro:
         channels['/gopro/image'] = ch('/gopro/image', img_sid)
+    if has_gopro_audio:
+        channels['/gopro/audio'] = ch('/gopro/audio', aud_sid)
     if has_accel:
         channels['/gopro/accel'] = ch('/gopro/accel', imu_sid)
     if has_gyro:
@@ -306,6 +309,7 @@ def export_episode_to_mcap(
 ) -> None:
     """Write one pzarr episode group to an MCAP file at output_path."""
     has_gopro = 'gopro/frames' in ep_grp
+    has_gopro_audio = 'gopro/audio' in ep_grp
     has_accel = 'gopro/accl' in ep_grp
     has_gyro = 'gopro/gyro' in ep_grp
     has_gps = 'gopro/gps' in ep_grp
@@ -318,6 +322,7 @@ def export_episode_to_mcap(
             ch = _register_channels(
                 writer,
                 has_gopro=has_gopro,
+                has_gopro_audio=has_gopro_audio,
                 has_accel=has_accel,
                 has_gyro=has_gyro,
                 has_gps=has_gps,
@@ -333,12 +338,12 @@ def export_episode_to_mcap(
                 quality=jpeg_quality,
             )
 
-            log.info('  audio...')
+            log.info('  finger audio...')
             _write_audio(
                 writer,
-                ch['/audio'],
-                ep_grp['audio/data'][:],  # type: ignore[index]
-                ep_grp['timestamps/audio'][:],  # type: ignore[index]
+                ch['/finger/audio'],
+                ep_grp['finger/audio'][:],  # type: ignore[index]
+                ep_grp['timestamps/finger_audio'][:],  # type: ignore[index]
                 chunk_size=audio_chunk_size,
             )
 
@@ -351,6 +356,16 @@ def export_episode_to_mcap(
                     ep_grp['timestamps/gopro'][:],  # type: ignore[index]
                     frame_id='gopro',
                     quality=jpeg_quality,
+                )
+
+            if has_gopro_audio:
+                log.info('  gopro audio...')
+                _write_audio(
+                    writer,
+                    ch['/gopro/audio'],
+                    ep_grp['gopro/audio'][:],  # type: ignore[index]
+                    ep_grp['timestamps/gopro_audio'][:],  # type: ignore[index]
+                    chunk_size=audio_chunk_size,
                 )
 
             if has_accel:

--- a/ingest/polyumi_ingest/export/mcap.py
+++ b/ingest/polyumi_ingest/export/mcap.py
@@ -1,0 +1,417 @@
+"""Export pzarr episodes to MCAP for visualization in Foxglove."""
+
+import base64
+import json
+import logging
+import pathlib
+
+import cv2
+import numpy as np
+import zarr
+from mcap.writer import Writer
+
+from polyumi_ingest.pzarr.scene_files import SceneFiles
+
+log = logging.getLogger('export.mcap')
+
+# ── Foxglove JSON schemas ─────────────────────────────────────────────────────
+
+_TIME = {
+    'type': 'object',
+    'properties': {
+        'sec': {'type': 'integer', 'minimum': 0},
+        'nsec': {'type': 'integer', 'minimum': 0, 'maximum': 999_999_999},
+    },
+}
+
+_VEC3 = {
+    'type': 'object',
+    'properties': {
+        'x': {'type': 'number'},
+        'y': {'type': 'number'},
+        'z': {'type': 'number'},
+    },
+}
+
+_SCHEMA_COMPRESSED_IMAGE = json.dumps(
+    {
+        '$schema': 'https://json-schema.org/draft/2020-12/schema',
+        'title': 'foxglove.CompressedImage',
+        'type': 'object',
+        'properties': {
+            'timestamp': _TIME,
+            'frame_id': {'type': 'string'},
+            'data': {'type': 'string', 'contentEncoding': 'base64'},
+            'format': {'type': 'string'},
+        },
+    }
+).encode()
+
+_SCHEMA_RAW_AUDIO = json.dumps(
+    {
+        '$schema': 'https://json-schema.org/draft/2020-12/schema',
+        'title': 'foxglove.RawAudio',
+        'type': 'object',
+        'properties': {
+            'timestamp': _TIME,
+            'format': {'type': 'string'},
+            'sample_rate': {'type': 'integer'},
+            'number_of_channels': {'type': 'integer'},
+            'data': {'type': 'string', 'contentEncoding': 'base64'},
+        },
+    }
+).encode()
+
+_SCHEMA_IMU = json.dumps(
+    {
+        '$schema': 'https://json-schema.org/draft/2020-12/schema',
+        'title': 'foxglove.Imu',
+        'type': 'object',
+        'properties': {
+            'timestamp': _TIME,
+            'frame_id': {'type': 'string'},
+            'orientation': {
+                'type': 'object',
+                'properties': {
+                    'x': {'type': 'number'},
+                    'y': {'type': 'number'},
+                    'z': {'type': 'number'},
+                    'w': {'type': 'number'},
+                },
+            },
+            'orientation_covariance': {'type': 'array', 'items': {'type': 'number'}},
+            'angular_velocity': _VEC3,
+            'angular_velocity_covariance': {'type': 'array', 'items': {'type': 'number'}},
+            'linear_acceleration': _VEC3,
+            'linear_acceleration_covariance': {'type': 'array', 'items': {'type': 'number'}},
+        },
+    }
+).encode()
+
+_SCHEMA_LOCATION_FIX = json.dumps(
+    {
+        '$schema': 'https://json-schema.org/draft/2020-12/schema',
+        'title': 'foxglove.LocationFix',
+        'type': 'object',
+        'properties': {
+            'timestamp': _TIME,
+            'frame_id': {'type': 'string'},
+            'latitude': {'type': 'number'},
+            'longitude': {'type': 'number'},
+            'altitude': {'type': 'number'},
+            'position_covariance': {'type': 'array', 'items': {'type': 'number'}},
+            'position_covariance_type': {'type': 'integer'},
+        },
+    }
+).encode()
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _ts_ns(t_s: float) -> int:
+    """Convert UTC seconds to integer nanoseconds."""
+    return int(t_s * 1e9)
+
+
+def _foxglove_time(t_s: float) -> dict:  # type: ignore[type-arg]
+    """Return a {sec, nsec} dict for Foxglove timestamp fields."""
+    ns = _ts_ns(t_s)
+    return {'sec': ns // 1_000_000_000, 'nsec': ns % 1_000_000_000}
+
+
+def _encode_jpeg(frame: np.ndarray, quality: int) -> bytes:
+    """Encode a (H, W, 3) uint8 BGR array to JPEG bytes."""
+    ok, buf = cv2.imencode('.jpg', frame, [cv2.IMWRITE_JPEG_QUALITY, quality])
+    if not ok:
+        raise RuntimeError('cv2.imencode failed')
+    return buf.tobytes()
+
+
+def _b64(data: bytes) -> str:
+    """Base64-encode bytes to an ASCII string for JSON embedding."""
+    return base64.b64encode(data).decode('ascii')
+
+
+# ── Channel registration ──────────────────────────────────────────────────────
+
+
+def _register_channels(
+    writer: Writer,
+    *,
+    has_gopro: bool,
+    has_accel: bool,
+    has_gyro: bool,
+    has_gps: bool,
+) -> dict[str, int]:
+    """Register all schemas and channels; return {topic: channel_id}."""
+    img_sid = writer.register_schema('foxglove.CompressedImage', 'jsonschema', _SCHEMA_COMPRESSED_IMAGE)
+    aud_sid = writer.register_schema('foxglove.RawAudio', 'jsonschema', _SCHEMA_RAW_AUDIO)
+    imu_sid = writer.register_schema('foxglove.Imu', 'jsonschema', _SCHEMA_IMU)
+    gps_sid = writer.register_schema('foxglove.LocationFix', 'jsonschema', _SCHEMA_LOCATION_FIX)
+
+    def ch(topic: str, sid: int) -> int:
+        return writer.register_channel(topic=topic, message_encoding='json', schema_id=sid)
+
+    channels: dict[str, int] = {
+        '/finger/image': ch('/finger/image', img_sid),
+        '/audio': ch('/audio', aud_sid),
+    }
+    if has_gopro:
+        channels['/gopro/image'] = ch('/gopro/image', img_sid)
+    if has_accel:
+        channels['/gopro/accel'] = ch('/gopro/accel', imu_sid)
+    if has_gyro:
+        channels['/gopro/gyro'] = ch('/gopro/gyro', imu_sid)
+    if has_gps:
+        channels['/gopro/gps'] = ch('/gopro/gps', gps_sid)
+    return channels
+
+
+# ── Per-stream writers ────────────────────────────────────────────────────────
+
+
+def _write_video(
+    writer: Writer,
+    channel_id: int,
+    frames_arr: zarr.Array,
+    ts: np.ndarray,
+    frame_id: str,
+    quality: int,
+) -> None:
+    """Write video frames as CompressedImage messages, re-encoding JpegXL → JPEG."""
+    n = len(ts)
+    log_every = max(1, n // 10)
+    for i in range(n):
+        if i % log_every == 0:
+            log.info(f'    {frame_id}: frame {i}/{n}')
+        jpeg = _encode_jpeg(frames_arr[i], quality)
+        t_s = float(ts[i])
+        msg = json.dumps(
+            {
+                'timestamp': _foxglove_time(t_s),
+                'frame_id': frame_id,
+                'data': _b64(jpeg),
+                'format': 'jpeg',
+            }
+        ).encode()
+        writer.add_message(channel_id=channel_id, log_time=_ts_ns(t_s), data=msg, publish_time=_ts_ns(t_s))
+
+
+def _write_audio(
+    writer: Writer,
+    channel_id: int,
+    audio_data: np.ndarray,
+    ts: np.ndarray,
+    chunk_size: int,
+) -> None:
+    """
+    Chunk audio into fixed-size blocks and write as RawAudio messages.
+
+    pzarr stores float32 audio; this converts to pcm-s16le for Foxglove compatibility,
+    matching the format sent by the streaming node.
+    """
+    n_samples = audio_data.shape[0]
+    n_channels = 1 if audio_data.ndim == 1 else audio_data.shape[1]
+    # Infer sample rate from timestamp spacing; fall back to 16 kHz if only one sample.
+    sr = int(round(1.0 / float(ts[1] - ts[0]))) if len(ts) > 1 else 16_000
+
+    for start in range(0, n_samples, chunk_size):
+        end = min(start + chunk_size, n_samples)
+        chunk = audio_data[start:end]
+        pcm = (chunk * 32_767).clip(-32_768, 32_767).astype('<i2')
+        t_s = float(ts[start])
+        msg = json.dumps(
+            {
+                'timestamp': _foxglove_time(t_s),
+                'format': 'pcm-s16le',
+                'sample_rate': sr,
+                'number_of_channels': n_channels,
+                'data': _b64(pcm.tobytes()),
+            }
+        ).encode()
+        writer.add_message(channel_id=channel_id, log_time=_ts_ns(t_s), data=msg, publish_time=_ts_ns(t_s))
+
+
+# -1 in the first covariance element is the ROS/Foxglove convention for "unknown".
+_UNKNOWN_COV9 = [-1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+
+
+def _write_imu(
+    writer: Writer,
+    channel_id: int,
+    data_arr: np.ndarray,
+    ts: np.ndarray,
+    field: str,
+) -> None:
+    """
+    Write accel or gyro samples as Imu messages.
+
+    field must be 'accel' or 'gyro'. GoPro's native z-x-y column order is
+    preserved as-is in the x, y, z fields of the Foxglove Imu message.
+    """
+    vec_key = 'linear_acceleration' if field == 'accel' else 'angular_velocity'
+    cov_key = vec_key + '_covariance'
+    for i in range(len(ts)):
+        row = data_arr[i]
+        t_s = float(ts[i])
+        msg = json.dumps(
+            {
+                'timestamp': _foxglove_time(t_s),
+                'frame_id': 'gopro_imu',
+                vec_key: {'x': float(row[0]), 'y': float(row[1]), 'z': float(row[2])},
+                cov_key: _UNKNOWN_COV9,
+            }
+        ).encode()
+        writer.add_message(channel_id=channel_id, log_time=_ts_ns(t_s), data=msg, publish_time=_ts_ns(t_s))
+
+
+def _write_gps(
+    writer: Writer,
+    channel_id: int,
+    gps_arr: np.ndarray,
+    ts: np.ndarray,
+) -> None:
+    """Write GPS samples as LocationFix messages using lat/lon/alt from the GPS5 columns."""
+    for i in range(len(ts)):
+        row = gps_arr[i]
+        t_s = float(ts[i])
+        msg = json.dumps(
+            {
+                'timestamp': _foxglove_time(t_s),
+                'frame_id': 'gopro_gps',
+                'latitude': float(row[0]),
+                'longitude': float(row[1]),
+                'altitude': float(row[2]),
+            }
+        ).encode()
+        writer.add_message(channel_id=channel_id, log_time=_ts_ns(t_s), data=msg, publish_time=_ts_ns(t_s))
+
+
+# ── Public API ────────────────────────────────────────────────────────────────
+
+
+def export_episode_to_mcap(
+    ep_grp: zarr.Group,
+    output_path: pathlib.Path,
+    jpeg_quality: int = 85,
+    audio_chunk_size: int = 4096,
+) -> None:
+    """Write one pzarr episode group to an MCAP file at output_path."""
+    has_gopro = 'gopro/frames' in ep_grp
+    has_accel = 'gopro/accl' in ep_grp
+    has_gyro = 'gopro/gyro' in ep_grp
+    has_gps = 'gopro/gps' in ep_grp
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, 'wb') as f:
+        writer = Writer(f)
+        writer.start(profile='', library='polyumi_ingest')
+        try:
+            ch = _register_channels(
+                writer,
+                has_gopro=has_gopro,
+                has_accel=has_accel,
+                has_gyro=has_gyro,
+                has_gps=has_gps,
+            )
+
+            log.info('  finger frames...')
+            _write_video(
+                writer,
+                ch['/finger/image'],
+                ep_grp['finger/frames'],  # type: ignore[index]
+                ep_grp['timestamps/finger'][:],  # type: ignore[index]
+                frame_id='finger',
+                quality=jpeg_quality,
+            )
+
+            log.info('  audio...')
+            _write_audio(
+                writer,
+                ch['/audio'],
+                ep_grp['audio/data'][:],  # type: ignore[index]
+                ep_grp['timestamps/audio'][:],  # type: ignore[index]
+                chunk_size=audio_chunk_size,
+            )
+
+            if has_gopro:
+                log.info('  gopro frames...')
+                _write_video(
+                    writer,
+                    ch['/gopro/image'],
+                    ep_grp['gopro/frames'],  # type: ignore[index]
+                    ep_grp['timestamps/gopro'][:],  # type: ignore[index]
+                    frame_id='gopro',
+                    quality=jpeg_quality,
+                )
+
+            if has_accel:
+                log.info('  accel...')
+                _write_imu(
+                    writer,
+                    ch['/gopro/accel'],
+                    ep_grp['gopro/accl'][:],  # type: ignore[index]
+                    ep_grp['timestamps/gopro_accl'][:],  # type: ignore[index]
+                    field='accel',
+                )
+
+            if has_gyro:
+                log.info('  gyro...')
+                _write_imu(
+                    writer,
+                    ch['/gopro/gyro'],
+                    ep_grp['gopro/gyro'][:],  # type: ignore[index]
+                    ep_grp['timestamps/gopro_gyro'][:],  # type: ignore[index]
+                    field='gyro',
+                )
+
+            if has_gps:
+                log.info('  gps...')
+                _write_gps(
+                    writer,
+                    ch['/gopro/gps'],
+                    ep_grp['gopro/gps'][:],  # type: ignore[index]
+                    ep_grp['timestamps/gopro_gps'][:],  # type: ignore[index]
+                )
+        finally:
+            writer.finish()
+
+
+def export_scene_to_mcap(
+    scene_path: pathlib.Path,
+    output_dir: pathlib.Path | None = None,
+    episode: int | None = None,
+    jpeg_quality: int = 85,
+    audio_chunk_size: int = 4096,
+) -> list[pathlib.Path]:
+    """
+    Export pzarr episodes from a scene to MCAP files, one file per episode.
+
+    Returns the list of written .mcap paths.
+    """
+    zarr_path = SceneFiles.resolve_zarr_path(scene_path)
+    if not zarr_path.exists():
+        raise FileNotFoundError(f'No scene.zarr found at {scene_path}')
+
+    root = zarr.open_group(str(zarr_path), mode='r')
+    n_episodes = int(root.attrs.get('n_episodes', 0))  # type: ignore[arg-type]
+
+    out_dir = output_dir if output_dir is not None else zarr_path.parent
+    ep_indices = [episode] if episode is not None else list(range(n_episodes))
+
+    written: list[pathlib.Path] = []
+    for ep_idx in ep_indices:
+        ep_key = f'episode_{ep_idx}'
+        if ep_key not in root:
+            log.warning(f'Episode {ep_idx} not found in {zarr_path.name}, skipping.')
+            continue
+        ep_grp = zarr.open_group(str(zarr_path / ep_key), mode='r')
+        out_path = out_dir / f'episode_{ep_idx}.mcap'
+        log.info(f'Exporting episode {ep_idx} → {out_path}')
+        export_episode_to_mcap(ep_grp, out_path, jpeg_quality, audio_chunk_size)
+        size_mb = out_path.stat().st_size / 1e6
+        log.info(f'  Done ({size_mb:.1f} MB)')
+        written.append(out_path)
+
+    return written

--- a/ingest/polyumi_ingest/export/mcap.py
+++ b/ingest/polyumi_ingest/export/mcap.py
@@ -4,6 +4,7 @@ import base64
 import json
 import logging
 import pathlib
+from concurrent.futures import ThreadPoolExecutor
 
 import numpy as np
 import zarr
@@ -181,22 +182,23 @@ def _write_video(
     n = len(ts)
     n_batches = (n + _ENCODE_BATCH - 1) // _ENCODE_BATCH
     log_every_batch = max(1, n_batches // 10)
-    for b, batch_start in enumerate(range(0, n, _ENCODE_BATCH)):
-        if b % log_every_batch == 0:
-            log.info(f'    {frame_id}: frame {batch_start}/{n}')
-        batch_end = min(batch_start + _ENCODE_BATCH, n)
-        jpegs = encode_frames_to_jpeg(frames_arr[batch_start:batch_end], quality)
-        for j, jpeg in enumerate(jpegs):
-            t_s = float(ts[batch_start + j])
-            msg = json.dumps(
-                {
-                    'timestamp': _foxglove_time(t_s),
-                    'frame_id': frame_id,
-                    'data': _b64(jpeg),
-                    'format': 'jpeg',
-                }
-            ).encode()
-            writer.add_message(channel_id=channel_id, log_time=_ts_ns(t_s), data=msg, publish_time=_ts_ns(t_s))
+    with ThreadPoolExecutor() as executor:
+        for b, batch_start in enumerate(range(0, n, _ENCODE_BATCH)):
+            if b % log_every_batch == 0:
+                log.info(f'    {frame_id}: frame {batch_start}/{n}')
+            batch_end = min(batch_start + _ENCODE_BATCH, n)
+            jpegs = encode_frames_to_jpeg(frames_arr[batch_start:batch_end], quality, executor)
+            for j, jpeg in enumerate(jpegs):
+                t_s = float(ts[batch_start + j])
+                msg = json.dumps(
+                    {
+                        'timestamp': _foxglove_time(t_s),
+                        'frame_id': frame_id,
+                        'data': _b64(jpeg),
+                        'format': 'jpeg',
+                    }
+                ).encode()
+                writer.add_message(channel_id=channel_id, log_time=_ts_ns(t_s), data=msg, publish_time=_ts_ns(t_s))
 
 
 def _write_audio(

--- a/ingest/polyumi_ingest/export/mcap.py
+++ b/ingest/polyumi_ingest/export/mcap.py
@@ -111,7 +111,7 @@ _SCHEMA_LOCATION_FIX = json.dumps(
 
 def _ts_ns(t_s: float) -> int:
     """Convert UTC seconds to integer nanoseconds."""
-    return int(t_s * 1e9)
+    return round(t_s * 1e9)
 
 
 def _foxglove_time(t_s: float) -> dict:  # type: ignore[type-arg]

--- a/ingest/polyumi_ingest/export/mcap.py
+++ b/ingest/polyumi_ingest/export/mcap.py
@@ -121,8 +121,14 @@ def _foxglove_time(t_s: float) -> dict:  # type: ignore[type-arg]
 
 
 def _encode_jpeg(frame: np.ndarray, quality: int) -> bytes:
-    """Encode a (H, W, 3) uint8 BGR array to JPEG bytes."""
-    ok, buf = cv2.imencode('.jpg', frame, [cv2.IMWRITE_JPEG_QUALITY, quality])
+    """
+    Encode a (H, W, 3) uint8 RGB array to JPEG bytes.
+
+    pzarr stores RGB (write_frames_to_zarr converts BGR→RGB on ingest), but
+    cv2.imencode expects BGR — convert back so JPEG colors come out correct.
+    """
+    bgr = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
+    ok, buf = cv2.imencode('.jpg', bgr, [cv2.IMWRITE_JPEG_QUALITY, quality])
     if not ok:
         raise RuntimeError('cv2.imencode failed')
     return buf.tobytes()
@@ -208,8 +214,9 @@ def _write_audio(
     """
     Chunk audio into fixed-size blocks and write as RawAudio messages.
 
-    pzarr stores float32 audio; this converts to pcm-s16le for Foxglove compatibility,
-    matching the format sent by the streaming node.
+    pzarr stores float32 audio; this converts to int16 PCM with format 'pcm-s16',
+    matching the format string used by the streaming node and recognized by
+    Foxglove's audio panel.
     """
     n_samples = audio_data.shape[0]
     n_channels = 1 if audio_data.ndim == 1 else audio_data.shape[1]
@@ -224,7 +231,7 @@ def _write_audio(
         msg = json.dumps(
             {
                 'timestamp': _foxglove_time(t_s),
-                'format': 'pcm-s16le',
+                'format': 'pcm-s16',
                 'sample_rate': sr,
                 'number_of_channels': n_channels,
                 'data': _b64(pcm.tobytes()),

--- a/ingest/polyumi_ingest/export/mcap.py
+++ b/ingest/polyumi_ingest/export/mcap.py
@@ -5,11 +5,11 @@ import json
 import logging
 import pathlib
 
-import cv2
 import numpy as np
 import zarr
 from mcap.writer import Writer
 
+from polyumi_ingest.export.helpers import encode_frames_to_jpeg
 from polyumi_ingest.pzarr.scene_files import SceneFiles
 
 log = logging.getLogger('export.mcap')
@@ -120,20 +120,6 @@ def _foxglove_time(t_s: float) -> dict:  # type: ignore[type-arg]
     return {'sec': ns // 1_000_000_000, 'nsec': ns % 1_000_000_000}
 
 
-def _encode_jpeg(frame: np.ndarray, quality: int) -> bytes:
-    """
-    Encode a (H, W, 3) uint8 RGB array to JPEG bytes.
-
-    pzarr stores RGB (write_frames_to_zarr converts BGR→RGB on ingest), but
-    cv2.imencode expects BGR — convert back so JPEG colors come out correct.
-    """
-    bgr = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
-    ok, buf = cv2.imencode('.jpg', bgr, [cv2.IMWRITE_JPEG_QUALITY, quality])
-    if not ok:
-        raise RuntimeError('cv2.imencode failed')
-    return buf.tobytes()
-
-
 def _b64(data: bytes) -> str:
     """Base64-encode bytes to an ASCII string for JSON embedding."""
     return base64.b64encode(data).decode('ascii')
@@ -180,6 +166,9 @@ def _register_channels(
 # ── Per-stream writers ────────────────────────────────────────────────────────
 
 
+_ENCODE_BATCH = 64
+
+
 def _write_video(
     writer: Writer,
     channel_id: int,
@@ -190,21 +179,24 @@ def _write_video(
 ) -> None:
     """Write video frames as CompressedImage messages, re-encoding JpegXL → JPEG."""
     n = len(ts)
-    log_every = max(1, n // 10)
-    for i in range(n):
-        if i % log_every == 0:
-            log.info(f'    {frame_id}: frame {i}/{n}')
-        jpeg = _encode_jpeg(frames_arr[i], quality)
-        t_s = float(ts[i])
-        msg = json.dumps(
-            {
-                'timestamp': _foxglove_time(t_s),
-                'frame_id': frame_id,
-                'data': _b64(jpeg),
-                'format': 'jpeg',
-            }
-        ).encode()
-        writer.add_message(channel_id=channel_id, log_time=_ts_ns(t_s), data=msg, publish_time=_ts_ns(t_s))
+    n_batches = (n + _ENCODE_BATCH - 1) // _ENCODE_BATCH
+    log_every_batch = max(1, n_batches // 10)
+    for b, batch_start in enumerate(range(0, n, _ENCODE_BATCH)):
+        if b % log_every_batch == 0:
+            log.info(f'    {frame_id}: frame {batch_start}/{n}')
+        batch_end = min(batch_start + _ENCODE_BATCH, n)
+        jpegs = encode_frames_to_jpeg(frames_arr[batch_start:batch_end], quality)
+        for j, jpeg in enumerate(jpegs):
+            t_s = float(ts[batch_start + j])
+            msg = json.dumps(
+                {
+                    'timestamp': _foxglove_time(t_s),
+                    'frame_id': frame_id,
+                    'data': _b64(jpeg),
+                    'format': 'jpeg',
+                }
+            ).encode()
+            writer.add_message(channel_id=channel_id, log_time=_ts_ns(t_s), data=msg, publish_time=_ts_ns(t_s))
 
 
 def _write_audio(

--- a/ingest/polyumi_ingest/main.py
+++ b/ingest/polyumi_ingest/main.py
@@ -377,11 +377,13 @@ def inspect_zarr(
                 if ep.gopro_ts_mean_delta_ms is not None:
                     ts_info += f'  (Δ={ep.gopro_ts_mean_delta_ms:.1f} ms avg)'
             table.add_row('gopro/frames', str(ep.gopro_shape), ts_info)
-        if ep.audio_shape is not None:
+        if ep.finger_audio_shape is not None:
             ts_info = ''
-            if ep.audio_ts_range is not None:
-                ts_info = f'{ep.audio_ts_range[0]:.3f} → {ep.audio_ts_range[1]:.3f} s'
-            table.add_row('audio/data', str(ep.audio_shape), ts_info)
+            if ep.finger_audio_ts_range is not None:
+                ts_info = f'{ep.finger_audio_ts_range[0]:.3f} → {ep.finger_audio_ts_range[1]:.3f} s'
+            table.add_row('finger/audio', str(ep.finger_audio_shape), ts_info)
+        if ep.gopro_audio_shape is not None:
+            table.add_row('gopro/audio', str(ep.gopro_audio_shape), '')
         if duration is not None:
             ep_info = f'{ep.episode_start:.3f} → {ep.episode_end:.3f} s  ({duration:.2f} s)'
             table.add_row('episode_start / end', '', ep_info)
@@ -415,7 +417,9 @@ def build_zarr(
 
     try:
         zarr_path = build_pzarr(scene_path, skip_gopro=skip_gopro)
-        log.info(f'Done. Zarr store written to {zarr_path}')
+        files = [f for f in zarr_path.rglob('*') if f.is_file()]
+        src_size = sum(f.stat().st_size for f in files)
+        log.info(f'Done. Zarr store written to {zarr_path} (total size: {_human_size(src_size)}).')
     except NotImplementedError as e:
         log.error(str(e))
         raise typer.Exit(1)
@@ -471,7 +475,7 @@ def archive_scene(
             raise typer.Exit(1)
         zip_path.unlink()
 
-    files = sorted(f for f in zarr_path.rglob('*') if f.is_file())
+    files = [f for f in zarr_path.rglob('*') if f.is_file()]
     src_size = sum(f.stat().st_size for f in files)
     log.info(f'Archiving {zarr_path} ({_human_size(src_size)}) → {zip_path}')
 

--- a/ingest/polyumi_ingest/main.py
+++ b/ingest/polyumi_ingest/main.py
@@ -383,7 +383,10 @@ def inspect_zarr(
                 ts_info = f'{ep.finger_audio_ts_range[0]:.3f} → {ep.finger_audio_ts_range[1]:.3f} s'
             table.add_row('finger/audio', str(ep.finger_audio_shape), ts_info)
         if ep.gopro_audio_shape is not None:
-            table.add_row('gopro/audio', str(ep.gopro_audio_shape), '')
+            ts_info = ''
+            if ep.gopro_audio_ts_range is not None:
+                ts_info = f'{ep.gopro_audio_ts_range[0]:.3f} → {ep.gopro_audio_ts_range[1]:.3f} s'
+            table.add_row('gopro/audio', str(ep.gopro_audio_shape), ts_info)
         if duration is not None:
             ep_info = f'{ep.episode_start:.3f} → {ep.episode_end:.3f} s  ({duration:.2f} s)'
             table.add_row('episode_start / end', '', ep_info)

--- a/ingest/polyumi_ingest/main.py
+++ b/ingest/polyumi_ingest/main.py
@@ -518,6 +518,7 @@ def export_mcap(
     ),
     audio_chunk_size: int = typer.Option(
         4096,
+        min=1,
         help='Number of audio samples per RawAudio message.',
     ),
 ):

--- a/ingest/polyumi_ingest/main.py
+++ b/ingest/polyumi_ingest/main.py
@@ -491,5 +491,48 @@ def archive_scene(
         log.info(f'Deleted {zarr_path}')
 
 
+@app.command(name='export-mcap')
+def export_mcap(
+    scene_path: pathlib.Path = typer.Argument(
+        ...,
+        help='Scene directory containing scene.zarr, or a scene.zarr path directly.',
+    ),
+    output_dir: pathlib.Path | None = typer.Option(
+        None,
+        help='Directory to write .mcap files. Defaults to the scene directory.',
+    ),
+    episode: int | None = typer.Option(
+        None,
+        help='Export only this episode index. Omit to export all episodes.',
+    ),
+    jpeg_quality: int = typer.Option(
+        85,
+        help='JPEG re-encode quality for video frames (1–100).',
+    ),
+    audio_chunk_size: int = typer.Option(
+        4096,
+        help='Number of audio samples per RawAudio message.',
+    ),
+):
+    """Export a pzarr scene to MCAP files for visualization in Foxglove."""
+    from polyumi_ingest.export.mcap import export_scene_to_mcap
+
+    try:
+        written = export_scene_to_mcap(
+            scene_path=scene_path,
+            output_dir=output_dir,
+            episode=episode,
+            jpeg_quality=jpeg_quality,
+            audio_chunk_size=audio_chunk_size,
+        )
+    except FileNotFoundError as e:
+        log.error(str(e))
+        raise typer.Exit(1)
+
+    log.info(f'Exported {len(written)} episode(s):')
+    for path in written:
+        log.info(f'  {path}')
+
+
 if __name__ == '__main__':
     app()

--- a/ingest/polyumi_ingest/pzarr/scene_files.py
+++ b/ingest/polyumi_ingest/pzarr/scene_files.py
@@ -57,8 +57,9 @@ class SceneFiles:
     def resolve_zarr_path(path: pathlib.Path) -> pathlib.Path:
         """Accept either a scene directory or a direct zarr path; return the zarr path."""
         path = path.resolve()
-        candidate = path / 'scene.zarr'
-        return candidate if candidate.exists() else path
+        if path.suffix == '.zarr':
+            return path
+        return path / 'scene.zarr'
 
     # --- zarr store ---
 

--- a/ingest/polyumi_ingest/pzarr/store.py
+++ b/ingest/polyumi_ingest/pzarr/store.py
@@ -3,6 +3,7 @@
 import dataclasses
 import datetime as dt
 import importlib.metadata
+import json
 import logging
 import pathlib
 import subprocess
@@ -128,6 +129,67 @@ def _write_gopro_imu(
         log.info(f'  GoPro GPS:  {n} samples (~{n / duration_s:.0f} Hz)')
 
 
+def _write_gopro_audio(
+    ep_grp: zarr.Group,
+    gopro_path: pathlib.Path,
+    recording_start_s: float,
+) -> None:
+    """
+    Extract audio from gopro.mp4 and write into ep_grp.
+
+    Writes to gopro/audio and timestamps/gopro_audio. Uses ffprobe to get the
+    native sample rate and channel count, then ffmpeg to extract raw float32 PCM.
+    """
+    try:
+        probe = subprocess.run(
+            ['ffprobe', '-v', 'quiet', '-print_format', 'json', '-show_streams', str(gopro_path)],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        log.warning(f'ffprobe failed on {gopro_path.name}: {exc}')
+        return
+
+    audio_info = None
+    for s in json.loads(probe.stdout).get('streams', []):
+        if s.get('codec_type') == 'audio':
+            audio_info = s
+            break
+
+    if audio_info is None:
+        log.info(f'  No audio stream in {gopro_path.name}')
+        return
+
+    sr = int(audio_info.get('sample_rate', 48000))
+    n_ch = int(audio_info.get('channels', 2))
+
+    try:
+        result = subprocess.run(
+            ['ffmpeg', '-i', str(gopro_path), '-vn', '-f', 'f32le', '-ar', str(sr), '-ac', str(n_ch), 'pipe:1'],
+            capture_output=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        log.warning(f'ffmpeg audio extraction failed on {gopro_path.name}: {exc}')
+        return
+
+    audio = np.frombuffer(result.stdout, dtype=np.float32)
+    if n_ch > 1:
+        audio = audio.reshape(-1, n_ch)
+    n_samples = audio.shape[0]
+
+    gopro_grp = ep_grp.require_group('gopro')
+    ts_grp = ep_grp.require_group('timestamps')
+    gopro_grp.create_array('audio', data=audio, compressor=_BLOSC)
+    ts_grp.create_array(
+        'gopro_audio',
+        data=recording_start_s + np.arange(n_samples, dtype=np.float64) / sr,
+        compressor=_BLOSC,
+    )
+    log.info(f'  GoPro audio: {n_samples} samples, {n_ch}ch @ {sr} Hz ({n_samples / sr:.1f}s)')
+
+
 def _write_gopro_frames(ep_grp: zarr.Group, gopro_path: pathlib.Path) -> None:
     """Decode gopro.mp4 and write frames, timestamps, and IMU into ep_grp."""
     cap = cv2.VideoCapture(str(gopro_path))
@@ -167,6 +229,7 @@ def _write_gopro_frames(ep_grp: zarr.Group, gopro_path: pathlib.Path) -> None:
         cap.release()
 
     _write_gopro_imu(ep_grp, gopro_path, recording_start_s, n_frames / fps)
+    _write_gopro_audio(ep_grp, gopro_path, recording_start_s)
 
 
 def _write_episode(ep_grp: zarr.Group, session: SessionFiles, skip_gopro: bool) -> None:
@@ -207,14 +270,13 @@ def _write_episode(ep_grp: zarr.Group, session: SessionFiles, skip_gopro: bool) 
     finger_ts = _finger_timestamps(video_dir, first_wall_ns)[:n_written]
     ts_grp.create_array('finger', data=finger_ts, compressor=_BLOSC)
 
-    # --- Audio ---
+    # --- Finger audio (contact microphone) ---
     if meta.audio_start_time_ns is None:
         raise RuntimeError(f'audio_start_time_ns missing in {session.path / "metadata.json"}')
     audio_data, sr = _read_wav(audio_path)
-    audio_grp = ep_grp.require_group('audio')
-    audio_grp.create_array('data', data=audio_data, compressor=_BLOSC)
+    finger_grp.create_array('audio', data=audio_data, compressor=_BLOSC)
     audio_ts = _audio_timestamps(meta.audio_start_time_ns, len(audio_data), sr)
-    ts_grp.create_array('audio', data=audio_ts, compressor=_BLOSC)
+    ts_grp.create_array('finger_audio', data=audio_ts, compressor=_BLOSC)
 
     # --- GoPro ---
     if skip_gopro:
@@ -273,14 +335,15 @@ class EpisodeInfo:
 
     index: int
     finger_shape: tuple | None  # type: ignore[type-arg]
-    audio_shape: tuple | None  # type: ignore[type-arg]
+    finger_audio_shape: tuple | None  # type: ignore[type-arg]
     gopro_shape: tuple | None  # type: ignore[type-arg]
     accl_shape: tuple | None  # type: ignore[type-arg]
     gyro_shape: tuple | None  # type: ignore[type-arg]
     gps_shape: tuple | None  # type: ignore[type-arg]
+    gopro_audio_shape: tuple | None  # type: ignore[type-arg]
     finger_ts_range: tuple[float, float] | None
     finger_ts_mean_delta_ms: float | None
-    audio_ts_range: tuple[float, float] | None
+    finger_audio_ts_range: tuple[float, float] | None
     gopro_ts_range: tuple[float, float] | None
     gopro_ts_mean_delta_ms: float | None
     episode_start: float | None
@@ -321,10 +384,10 @@ def inspect_pzarr(scene_path: pathlib.Path) -> PZarrInfo:
             finger_ts_range = (float(ts[0]), float(ts[-1]))
             finger_mean_delta = float(np.diff(ts).mean() * 1000) if len(ts) > 1 else None
 
-        audio_ts_range: tuple[float, float] | None = None
-        if 'timestamps/audio' in ep:
-            ts = _arr(ep, 'timestamps/audio')[:]  # type: ignore[assignment]
-            audio_ts_range = (float(ts[0]), float(ts[-1]))
+        finger_audio_ts_range: tuple[float, float] | None = None
+        if 'timestamps/finger_audio' in ep:
+            ts = _arr(ep, 'timestamps/finger_audio')[:]  # type: ignore[assignment]
+            finger_audio_ts_range = (float(ts[0]), float(ts[-1]))
 
         gopro_ts_range: tuple[float, float] | None = None
         gopro_mean_delta: float | None = None
@@ -347,14 +410,15 @@ def inspect_pzarr(scene_path: pathlib.Path) -> PZarrInfo:
             EpisodeInfo(
                 index=i,
                 finger_shape=_arr(ep, 'finger/frames').shape if 'finger/frames' in ep else None,
-                audio_shape=_arr(ep, 'audio/data').shape if 'audio/data' in ep else None,
+                finger_audio_shape=_arr(ep, 'finger/audio').shape if 'finger/audio' in ep else None,
                 gopro_shape=_arr(ep, 'gopro/frames').shape if 'gopro/frames' in ep else None,
                 accl_shape=_arr(ep, 'gopro/accl').shape if 'gopro/accl' in ep else None,
                 gyro_shape=_arr(ep, 'gopro/gyro').shape if 'gopro/gyro' in ep else None,
                 gps_shape=_arr(ep, 'gopro/gps').shape if 'gopro/gps' in ep else None,
+                gopro_audio_shape=_arr(ep, 'gopro/audio').shape if 'gopro/audio' in ep else None,
                 finger_ts_range=finger_ts_range,
                 finger_ts_mean_delta_ms=finger_mean_delta,
-                audio_ts_range=audio_ts_range,
+                finger_audio_ts_range=finger_audio_ts_range,
                 gopro_ts_range=gopro_ts_range,
                 gopro_ts_mean_delta_ms=gopro_mean_delta,
                 episode_start=ep_start,

--- a/ingest/polyumi_ingest/pzarr/store.py
+++ b/ingest/polyumi_ingest/pzarr/store.py
@@ -163,6 +163,9 @@ def _write_gopro_audio(
 
     sr = int(audio_info.get('sample_rate', 48000))
     n_ch = int(audio_info.get('channels', 2))
+    duration_s = float(audio_info.get('duration', 0) or 0)
+    expected_mb = duration_s * sr * n_ch * 4 / 1e6
+    log.info(f'  GoPro audio: {sr} Hz {n_ch}ch ~{duration_s:.1f}s → ~{expected_mb:.0f} MB RAM')
 
     try:
         result = subprocess.run(
@@ -341,6 +344,7 @@ class EpisodeInfo:
     gyro_shape: tuple | None  # type: ignore[type-arg]
     gps_shape: tuple | None  # type: ignore[type-arg]
     gopro_audio_shape: tuple | None  # type: ignore[type-arg]
+    gopro_audio_ts_range: tuple[float, float] | None
     finger_ts_range: tuple[float, float] | None
     finger_ts_mean_delta_ms: float | None
     finger_audio_ts_range: tuple[float, float] | None
@@ -389,6 +393,11 @@ def inspect_pzarr(scene_path: pathlib.Path) -> PZarrInfo:
             ts = _arr(ep, 'timestamps/finger_audio')[:]  # type: ignore[assignment]
             finger_audio_ts_range = (float(ts[0]), float(ts[-1]))
 
+        gopro_audio_ts_range: tuple[float, float] | None = None
+        if 'timestamps/gopro_audio' in ep:
+            ts = _arr(ep, 'timestamps/gopro_audio')[:]  # type: ignore[assignment]
+            gopro_audio_ts_range = (float(ts[0]), float(ts[-1]))
+
         gopro_ts_range: tuple[float, float] | None = None
         gopro_mean_delta: float | None = None
         if 'timestamps/gopro' in ep:
@@ -416,6 +425,7 @@ def inspect_pzarr(scene_path: pathlib.Path) -> PZarrInfo:
                 gyro_shape=_arr(ep, 'gopro/gyro').shape if 'gopro/gyro' in ep else None,
                 gps_shape=_arr(ep, 'gopro/gps').shape if 'gopro/gps' in ep else None,
                 gopro_audio_shape=_arr(ep, 'gopro/audio').shape if 'gopro/audio' in ep else None,
+                gopro_audio_ts_range=gopro_audio_ts_range,
                 finger_ts_range=finger_ts_range,
                 finger_ts_mean_delta_ms=finger_mean_delta,
                 finger_audio_ts_range=finger_audio_ts_range,

--- a/ingest/pyproject.toml
+++ b/ingest/pyproject.toml
@@ -21,3 +21,4 @@ polyumi_pi = { path = "../pi", editable = true }
 
 [project.scripts]
 pingest = "polyumi_ingest.main:app"
+

--- a/ingest/pyproject.toml
+++ b/ingest/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "numcodecs",
     "imagecodecs",
     "pillow",
+    "mcap>=1.1",
 ]
 
 [tool.uv.sources]

--- a/uv.lock
+++ b/uv.lock
@@ -439,6 +439,38 @@ wheels = [
 ]
 
 [[package]]
+name = "lz4"
+version = "4.4.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/51/f1b86d93029f418033dddf9b9f79c8d2641e7454080478ee2aab5123173e/lz4-4.4.5.tar.gz", hash = "sha256:5f0b9e53c1e82e88c10d7c180069363980136b9d7a8306c4dca4f760d60c39f0", size = 172886, upload-time = "2025-11-03T13:02:36.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/46/08fd8ef19b782f301d56a9ccfd7dafec5fd4fc1a9f017cf22a1accb585d7/lz4-4.4.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6bb05416444fafea170b07181bc70640975ecc2a8c92b3b658c554119519716c", size = 207171, upload-time = "2025-11-03T13:01:56.595Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/3f/ea3334e59de30871d773963997ecdba96c4584c5f8007fd83cfc8f1ee935/lz4-4.4.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b424df1076e40d4e884cfcc4c77d815368b7fb9ebcd7e634f937725cd9a8a72a", size = 207163, upload-time = "2025-11-03T13:01:57.721Z" },
+    { url = "https://files.pythonhosted.org/packages/41/7b/7b3a2a0feb998969f4793c650bb16eff5b06e80d1f7bff867feb332f2af2/lz4-4.4.5-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:216ca0c6c90719731c64f41cfbd6f27a736d7e50a10b70fad2a9c9b262ec923d", size = 1292136, upload-time = "2025-11-03T13:02:00.375Z" },
+    { url = "https://files.pythonhosted.org/packages/89/d1/f1d259352227bb1c185288dd694121ea303e43404aa77560b879c90e7073/lz4-4.4.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:533298d208b58b651662dd972f52d807d48915176e5b032fb4f8c3b6f5fe535c", size = 1279639, upload-time = "2025-11-03T13:02:01.649Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/fb/ba9256c48266a09012ed1d9b0253b9aa4fe9cdff094f8febf5b26a4aa2a2/lz4-4.4.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:451039b609b9a88a934800b5fc6ee401c89ad9c175abf2f4d9f8b2e4ef1afc64", size = 1368257, upload-time = "2025-11-03T13:02:03.35Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/6d/dee32a9430c8b0e01bbb4537573cabd00555827f1a0a42d4e24ca803935c/lz4-4.4.5-cp313-cp313-win32.whl", hash = "sha256:a5f197ffa6fc0e93207b0af71b302e0a2f6f29982e5de0fbda61606dd3a55832", size = 88191, upload-time = "2025-11-03T13:02:04.406Z" },
+    { url = "https://files.pythonhosted.org/packages/18/e0/f06028aea741bbecb2a7e9648f4643235279a770c7ffaf70bd4860c73661/lz4-4.4.5-cp313-cp313-win_amd64.whl", hash = "sha256:da68497f78953017deb20edff0dba95641cc86e7423dfadf7c0264e1ac60dc22", size = 99502, upload-time = "2025-11-03T13:02:05.886Z" },
+    { url = "https://files.pythonhosted.org/packages/61/72/5bef44afb303e56078676b9f2486f13173a3c1e7f17eaac1793538174817/lz4-4.4.5-cp313-cp313-win_arm64.whl", hash = "sha256:c1cfa663468a189dab510ab231aad030970593f997746d7a324d40104db0d0a9", size = 91285, upload-time = "2025-11-03T13:02:06.77Z" },
+    { url = "https://files.pythonhosted.org/packages/49/55/6a5c2952971af73f15ed4ebfdd69774b454bd0dc905b289082ca8664fba1/lz4-4.4.5-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:67531da3b62f49c939e09d56492baf397175ff39926d0bd5bd2d191ac2bff95f", size = 207348, upload-time = "2025-11-03T13:02:08.117Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/d7/fd62cbdbdccc35341e83aabdb3f6d5c19be2687d0a4eaf6457ddf53bba64/lz4-4.4.5-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a1acbbba9edbcbb982bc2cac5e7108f0f553aebac1040fbec67a011a45afa1ba", size = 207340, upload-time = "2025-11-03T13:02:09.152Z" },
+    { url = "https://files.pythonhosted.org/packages/77/69/225ffadaacb4b0e0eb5fd263541edd938f16cd21fe1eae3cd6d5b6a259dc/lz4-4.4.5-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:a482eecc0b7829c89b498fda883dbd50e98153a116de612ee7c111c8bcf82d1d", size = 1293398, upload-time = "2025-11-03T13:02:10.272Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/9e/2ce59ba4a21ea5dc43460cba6f34584e187328019abc0e66698f2b66c881/lz4-4.4.5-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e099ddfaa88f59dd8d36c8a3c66bd982b4984edf127eb18e30bb49bdba68ce67", size = 1281209, upload-time = "2025-11-03T13:02:12.091Z" },
+    { url = "https://files.pythonhosted.org/packages/80/4f/4d946bd1624ec229b386a3bc8e7a85fa9a963d67d0a62043f0af0978d3da/lz4-4.4.5-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2af2897333b421360fdcce895c6f6281dc3fab018d19d341cf64d043fc8d90d", size = 1369406, upload-time = "2025-11-03T13:02:13.683Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a2/d429ba4720a9064722698b4b754fb93e42e625f1318b8fe834086c7c783b/lz4-4.4.5-cp313-cp313t-win32.whl", hash = "sha256:66c5de72bf4988e1b284ebdd6524c4bead2c507a2d7f172201572bac6f593901", size = 88325, upload-time = "2025-11-03T13:02:14.743Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/85/7ba10c9b97c06af6c8f7032ec942ff127558863df52d866019ce9d2425cf/lz4-4.4.5-cp313-cp313t-win_amd64.whl", hash = "sha256:cdd4bdcbaf35056086d910d219106f6a04e1ab0daa40ec0eeef1626c27d0fddb", size = 99643, upload-time = "2025-11-03T13:02:15.978Z" },
+    { url = "https://files.pythonhosted.org/packages/77/4d/a175459fb29f909e13e57c8f475181ad8085d8d7869bd8ad99033e3ee5fa/lz4-4.4.5-cp313-cp313t-win_arm64.whl", hash = "sha256:28ccaeb7c5222454cd5f60fcd152564205bcb801bd80e125949d2dfbadc76bbd", size = 91504, upload-time = "2025-11-03T13:02:17.313Z" },
+    { url = "https://files.pythonhosted.org/packages/63/9c/70bdbdb9f54053a308b200b4678afd13efd0eafb6ddcbb7f00077213c2e5/lz4-4.4.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c216b6d5275fc060c6280936bb3bb0e0be6126afb08abccde27eed23dead135f", size = 207586, upload-time = "2025-11-03T13:02:18.263Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/cb/bfead8f437741ce51e14b3c7d404e3a1f6b409c440bad9b8f3945d4c40a7/lz4-4.4.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c8e71b14938082ebaf78144f3b3917ac715f72d14c076f384a4c062df96f9df6", size = 207161, upload-time = "2025-11-03T13:02:19.286Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/18/b192b2ce465dfbeabc4fc957ece7a1d34aded0d95a588862f1c8a86ac448/lz4-4.4.5-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:9b5e6abca8df9f9bdc5c3085f33ff32cdc86ed04c65e0355506d46a5ac19b6e9", size = 1292415, upload-time = "2025-11-03T13:02:20.829Z" },
+    { url = "https://files.pythonhosted.org/packages/67/79/a4e91872ab60f5e89bfad3e996ea7dc74a30f27253faf95865771225ccba/lz4-4.4.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3b84a42da86e8ad8537aabef062e7f661f4a877d1c74d65606c49d835d36d668", size = 1279920, upload-time = "2025-11-03T13:02:22.013Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/01/d52c7b11eaa286d49dae619c0eec4aabc0bf3cda7a7467eb77c62c4471f3/lz4-4.4.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bba042ec5a61fa77c7e380351a61cb768277801240249841defd2ff0a10742f", size = 1368661, upload-time = "2025-11-03T13:02:23.208Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/da/137ddeea14c2cb86864838277b2607d09f8253f152156a07f84e11768a28/lz4-4.4.5-cp314-cp314-win32.whl", hash = "sha256:bd85d118316b53ed73956435bee1997bd06cc66dd2fa74073e3b1322bd520a67", size = 90139, upload-time = "2025-11-03T13:02:24.301Z" },
+    { url = "https://files.pythonhosted.org/packages/18/2c/8332080fd293f8337779a440b3a143f85e374311705d243439a3349b81ad/lz4-4.4.5-cp314-cp314-win_amd64.whl", hash = "sha256:92159782a4502858a21e0079d77cdcaade23e8a5d252ddf46b0652604300d7be", size = 101497, upload-time = "2025-11-03T13:02:25.187Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/28/2635a8141c9a4f4bc23f5135a92bbcf48d928d8ca094088c962df1879d64/lz4-4.4.5-cp314-cp314-win_arm64.whl", hash = "sha256:d994b87abaa7a88ceb7a37c90f547b8284ff9da694e6afcfaa8568d739faf3f7", size = 93812, upload-time = "2025-11-03T13:02:26.133Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -448,6 +480,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "mcap"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lz4" },
+    { name = "zstandard" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/38/8bd73953b9c37dd7a2c590e72ab4fa4682a43864fe1d55f7209f2536fa64/mcap-1.3.1.tar.gz", hash = "sha256:2878879a786021aa7f7f36319276396a778717ccd013b2191fe94d37572d7551", size = 21676, upload-time = "2025-12-24T21:31:35.476Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/22/dad47e86047344f110a9d589d90de49d9c54db7a7ea4f0ef91fb3e8e9f3f/mcap-1.3.1-py3-none-any.whl", hash = "sha256:9098685d67288a8087166504cf4adf617cfa8639bb60e936af113f62c11c293f", size = 20678, upload-time = "2025-12-24T21:31:33.959Z" },
 ]
 
 [[package]]
@@ -769,6 +814,7 @@ version = "0.1.0"
 source = { editable = "ingest" }
 dependencies = [
     { name = "imagecodecs" },
+    { name = "mcap" },
     { name = "numcodecs" },
     { name = "pillow" },
     { name = "polyumi-pi" },
@@ -778,6 +824,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "imagecodecs" },
+    { name = "mcap", specifier = ">=1.1" },
     { name = "numcodecs" },
     { name = "pillow" },
     { name = "polyumi-pi", editable = "pi" },
@@ -1690,4 +1737,44 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c4/05/f8b88937659075116c122355bdd9ce52376cc46e2269d91d7d4f10c9a658/zeroconf-0.148.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f6e3dd22732df47a126aefb5ca4b267e828b47098a945d4468d38c72843dd6df", size = 4311455, upload-time = "2025-10-05T01:09:22.042Z" },
     { url = "https://files.pythonhosted.org/packages/58/c0/359bdb3b435d9c573aec1f877f8a63d5e81145deb6c160de89647b237363/zeroconf-0.148.0-cp314-cp314t-win32.whl", hash = "sha256:cdc8083f0b5efa908ab6c8e41687bcb75fd3d23f49ee0f34cbc58422437a456f", size = 2755961, upload-time = "2025-10-05T01:09:24.041Z" },
     { url = "https://files.pythonhosted.org/packages/d8/ab/7b487afd5d1fd053c5a018565be734ac6d5e554bce938c7cc126154adcfc/zeroconf-0.148.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f72c1f77a89638e87f243a63979f0fd921ce391f83e18e17ec88f9f453717701", size = 3309977, upload-time = "2025-10-05T01:09:26.039Z" },
+]
+
+[[package]]
+name = "zstandard"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/aa/3e0508d5a5dd96529cdc5a97011299056e14c6505b678fd58938792794b1/zstandard-0.25.0.tar.gz", hash = "sha256:7713e1179d162cf5c7906da876ec2ccb9c3a9dcbdffef0cc7f70c3667a205f0b", size = 711513, upload-time = "2025-09-14T22:15:54.002Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/0b/8df9c4ad06af91d39e94fa96cc010a24ac4ef1378d3efab9223cc8593d40/zstandard-0.25.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ec996f12524f88e151c339688c3897194821d7f03081ab35d31d1e12ec975e94", size = 795735, upload-time = "2025-09-14T22:17:26.042Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/06/9ae96a3e5dcfd119377ba33d4c42a7d89da1efabd5cb3e366b156c45ff4d/zstandard-0.25.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a1a4ae2dec3993a32247995bdfe367fc3266da832d82f8438c8570f989753de1", size = 640440, upload-time = "2025-09-14T22:17:27.366Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/14/933d27204c2bd404229c69f445862454dcc101cd69ef8c6068f15aaec12c/zstandard-0.25.0-cp313-cp313-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:e96594a5537722fdfb79951672a2a63aec5ebfb823e7560586f7484819f2a08f", size = 5343070, upload-time = "2025-09-14T22:17:28.896Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/db/ddb11011826ed7db9d0e485d13df79b58586bfdec56e5c84a928a9a78c1c/zstandard-0.25.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:bfc4e20784722098822e3eee42b8e576b379ed72cca4a7cb856ae733e62192ea", size = 5063001, upload-time = "2025-09-14T22:17:31.044Z" },
+    { url = "https://files.pythonhosted.org/packages/db/00/87466ea3f99599d02a5238498b87bf84a6348290c19571051839ca943777/zstandard-0.25.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:457ed498fc58cdc12fc48f7950e02740d4f7ae9493dd4ab2168a47c93c31298e", size = 5394120, upload-time = "2025-09-14T22:17:32.711Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/95/fc5531d9c618a679a20ff6c29e2b3ef1d1f4ad66c5e161ae6ff847d102a9/zstandard-0.25.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:fd7a5004eb1980d3cefe26b2685bcb0b17989901a70a1040d1ac86f1d898c551", size = 5451230, upload-time = "2025-09-14T22:17:34.41Z" },
+    { url = "https://files.pythonhosted.org/packages/63/4b/e3678b4e776db00f9f7b2fe58e547e8928ef32727d7a1ff01dea010f3f13/zstandard-0.25.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8e735494da3db08694d26480f1493ad2cf86e99bdd53e8e9771b2752a5c0246a", size = 5547173, upload-time = "2025-09-14T22:17:36.084Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/d5/ba05ed95c6b8ec30bd468dfeab20589f2cf709b5c940483e31d991f2ca58/zstandard-0.25.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3a39c94ad7866160a4a46d772e43311a743c316942037671beb264e395bdd611", size = 5046736, upload-time = "2025-09-14T22:17:37.891Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d5/870aa06b3a76c73eced65c044b92286a3c4e00554005ff51962deef28e28/zstandard-0.25.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:172de1f06947577d3a3005416977cce6168f2261284c02080e7ad0185faeced3", size = 5576368, upload-time = "2025-09-14T22:17:40.206Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/35/398dc2ffc89d304d59bc12f0fdd931b4ce455bddf7038a0a67733a25f550/zstandard-0.25.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3c83b0188c852a47cd13ef3bf9209fb0a77fa5374958b8c53aaa699398c6bd7b", size = 4954022, upload-time = "2025-09-14T22:17:41.879Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/5c/36ba1e5507d56d2213202ec2b05e8541734af5f2ce378c5d1ceaf4d88dc4/zstandard-0.25.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:1673b7199bbe763365b81a4f3252b8e80f44c9e323fc42940dc8843bfeaf9851", size = 5267889, upload-time = "2025-09-14T22:17:43.577Z" },
+    { url = "https://files.pythonhosted.org/packages/70/e8/2ec6b6fb7358b2ec0113ae202647ca7c0e9d15b61c005ae5225ad0995df5/zstandard-0.25.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:0be7622c37c183406f3dbf0cba104118eb16a4ea7359eeb5752f0794882fc250", size = 5433952, upload-time = "2025-09-14T22:17:45.271Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/01/b5f4d4dbc59ef193e870495c6f1275f5b2928e01ff5a81fecb22a06e22fb/zstandard-0.25.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:5f5e4c2a23ca271c218ac025bd7d635597048b366d6f31f420aaeb715239fc98", size = 5814054, upload-time = "2025-09-14T22:17:47.08Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/e5/fbd822d5c6f427cf158316d012c5a12f233473c2f9c5fe5ab1ae5d21f3d8/zstandard-0.25.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4f187a0bb61b35119d1926aee039524d1f93aaf38a9916b8c4b78ac8514a0aaf", size = 5360113, upload-time = "2025-09-14T22:17:48.893Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e0/69a553d2047f9a2c7347caa225bb3a63b6d7704ad74610cb7823baa08ed7/zstandard-0.25.0-cp313-cp313-win32.whl", hash = "sha256:7030defa83eef3e51ff26f0b7bfb229f0204b66fe18e04359ce3474ac33cbc09", size = 436936, upload-time = "2025-09-14T22:17:52.658Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/82/b9c06c870f3bd8767c201f1edbdf9e8dc34be5b0fbc5682c4f80fe948475/zstandard-0.25.0-cp313-cp313-win_amd64.whl", hash = "sha256:1f830a0dac88719af0ae43b8b2d6aef487d437036468ef3c2ea59c51f9d55fd5", size = 506232, upload-time = "2025-09-14T22:17:50.402Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/60c3c01243bb81d381c9916e2a6d9e149ab8627c0c7d7abb2d73384b3c0c/zstandard-0.25.0-cp313-cp313-win_arm64.whl", hash = "sha256:85304a43f4d513f5464ceb938aa02c1e78c2943b29f44a750b48b25ac999a049", size = 462671, upload-time = "2025-09-14T22:17:51.533Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/5c/f8923b595b55fe49e30612987ad8bf053aef555c14f05bb659dd5dbe3e8a/zstandard-0.25.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e29f0cf06974c899b2c188ef7f783607dbef36da4c242eb6c82dcd8b512855e3", size = 795887, upload-time = "2025-09-14T22:17:54.198Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/09/d0a2a14fc3439c5f874042dca72a79c70a532090b7ba0003be73fee37ae2/zstandard-0.25.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:05df5136bc5a011f33cd25bc9f506e7426c0c9b3f9954f056831ce68f3b6689f", size = 640658, upload-time = "2025-09-14T22:17:55.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7c/8b6b71b1ddd517f68ffb55e10834388d4f793c49c6b83effaaa05785b0b4/zstandard-0.25.0-cp314-cp314-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:f604efd28f239cc21b3adb53eb061e2a205dc164be408e553b41ba2ffe0ca15c", size = 5379849, upload-time = "2025-09-14T22:17:57.372Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/86/a48e56320d0a17189ab7a42645387334fba2200e904ee47fc5a26c1fd8ca/zstandard-0.25.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223415140608d0f0da010499eaa8ccdb9af210a543fac54bce15babbcfc78439", size = 5058095, upload-time = "2025-09-14T22:17:59.498Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ad/eb659984ee2c0a779f9d06dbfe45e2dc39d99ff40a319895df2d3d9a48e5/zstandard-0.25.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2e54296a283f3ab5a26fc9b8b5d4978ea0532f37b231644f367aa588930aa043", size = 5551751, upload-time = "2025-09-14T22:18:01.618Z" },
+    { url = "https://files.pythonhosted.org/packages/61/b3/b637faea43677eb7bd42ab204dfb7053bd5c4582bfe6b1baefa80ac0c47b/zstandard-0.25.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ca54090275939dc8ec5dea2d2afb400e0f83444b2fc24e07df7fdef677110859", size = 6364818, upload-time = "2025-09-14T22:18:03.769Z" },
+    { url = "https://files.pythonhosted.org/packages/31/dc/cc50210e11e465c975462439a492516a73300ab8caa8f5e0902544fd748b/zstandard-0.25.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e09bb6252b6476d8d56100e8147b803befa9a12cea144bbe629dd508800d1ad0", size = 5560402, upload-time = "2025-09-14T22:18:05.954Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ae/56523ae9c142f0c08efd5e868a6da613ae76614eca1305259c3bf6a0ed43/zstandard-0.25.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a9ec8c642d1ec73287ae3e726792dd86c96f5681eb8df274a757bf62b750eae7", size = 4955108, upload-time = "2025-09-14T22:18:07.68Z" },
+    { url = "https://files.pythonhosted.org/packages/98/cf/c899f2d6df0840d5e384cf4c4121458c72802e8bda19691f3b16619f51e9/zstandard-0.25.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a4089a10e598eae6393756b036e0f419e8c1d60f44a831520f9af41c14216cf2", size = 5269248, upload-time = "2025-09-14T22:18:09.753Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/c0/59e912a531d91e1c192d3085fc0f6fb2852753c301a812d856d857ea03c6/zstandard-0.25.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:f67e8f1a324a900e75b5e28ffb152bcac9fbed1cc7b43f99cd90f395c4375344", size = 5430330, upload-time = "2025-09-14T22:18:11.966Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/7e31db1240de2df22a58e2ea9a93fc6e38cc29353e660c0272b6735d6669/zstandard-0.25.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:9654dbc012d8b06fc3d19cc825af3f7bf8ae242226df5f83936cb39f5fdc846c", size = 5811123, upload-time = "2025-09-14T22:18:13.907Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/49/fac46df5ad353d50535e118d6983069df68ca5908d4d65b8c466150a4ff1/zstandard-0.25.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4203ce3b31aec23012d3a4cf4a2ed64d12fea5269c49aed5e4c3611b938e4088", size = 5359591, upload-time = "2025-09-14T22:18:16.465Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/38/f249a2050ad1eea0bb364046153942e34abba95dd5520af199aed86fbb49/zstandard-0.25.0-cp314-cp314-win32.whl", hash = "sha256:da469dc041701583e34de852d8634703550348d5822e66a0c827d39b05365b12", size = 444513, upload-time = "2025-09-14T22:18:20.61Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/43/241f9615bcf8ba8903b3f0432da069e857fc4fd1783bd26183db53c4804b/zstandard-0.25.0-cp314-cp314-win_amd64.whl", hash = "sha256:c19bcdd826e95671065f8692b5a4aa95c52dc7a02a4c5a0cac46deb879a017a2", size = 516118, upload-time = "2025-09-14T22:18:17.849Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ef/da163ce2450ed4febf6467d77ccb4cd52c4c30ab45624bad26ca0a27260c/zstandard-0.25.0-cp314-cp314-win_arm64.whl", hash = "sha256:d7541afd73985c630bafcd6338d2518ae96060075f9463d7dc14cfb33514383d", size = 476940, upload-time = "2025-09-14T22:18:19.088Z" },
 ]


### PR DESCRIPTION
#23 

Enabled pzarr episodes to be visualized in foxglove by adding a pzarr->mcap export script.
Also added gopro audio to pzarr.

Doing this has made obvious a few bugs, including the fact that timestamps are definitely not yet perfectly synced.