### PR TITLE
Catalog UI updates

### DIFF
--- a/catalog/polyumi_catalog/app.py
+++ b/catalog/polyumi_catalog/app.py
@@ -107,8 +107,9 @@ def create_app(engine: Engine, recordings_dir: pathlib.Path | None = None) -> Fa
 
     def _detail_with_episodes_oob(db: DBSession, session_id: str) -> HTMLResponse:
         """
-        Re-render the session detail pane plus an out-of-band update of its scene's Episodes
-        column, so a usable/unusable toggle grey-out is reflected immediately if that scene's
+        Re-render the session detail pane plus an out-of-band update of its scene's Episodes column.
+
+        This keeps a usable/unusable toggle's grey-out reflected immediately if that scene's
         episode list happens to be open (same "update a currently-visible widget" pattern as
         the dataset-draft builder — see the module docstring's Phase 3 paragraph).
         """
@@ -325,23 +326,21 @@ def create_app(engine: Engine, recordings_dir: pathlib.Path | None = None) -> Fa
             detail = queries.session_detail(db, session_id)
         return render(request, '_detail.html', detail=detail, oob=False)
 
-    @app.post('/sessions/{session_id}/mark-unusable', response_class=HTMLResponse)
-    def post_mark_unusable(session_id: str) -> HTMLResponse:
+    def _post_mark_usable(session_id: str, unusable: bool) -> HTMLResponse:
         with DBSession(engine) as db:
             try:
-                set_session_unusable(db, session_id, True)
+                set_session_unusable(db, session_id, unusable)
             except MutationError as err:
                 return PlainTextResponse(str(err), status_code=400)
             return _detail_with_episodes_oob(db, session_id)
 
+    @app.post('/sessions/{session_id}/mark-unusable', response_class=HTMLResponse)
+    def post_mark_unusable(session_id: str) -> HTMLResponse:
+        return _post_mark_usable(session_id, True)
+
     @app.post('/sessions/{session_id}/mark-usable', response_class=HTMLResponse)
     def post_mark_usable(session_id: str) -> HTMLResponse:
-        with DBSession(engine) as db:
-            try:
-                set_session_unusable(db, session_id, False)
-            except MutationError as err:
-                return PlainTextResponse(str(err), status_code=400)
-            return _detail_with_episodes_oob(db, session_id)
+        return _post_mark_usable(session_id, False)
 
     @app.post('/scenes/{scene_id}/run-pp', response_class=HTMLResponse)
     def post_run_pp(request: Request, scene_id: str) -> HTMLResponse:

--- a/catalog/polyumi_catalog/app.py
+++ b/catalog/polyumi_catalog/app.py
@@ -45,6 +45,11 @@ Phase 6 adds editable notes for both scenes and sessions: an HTMX form POST that
 the first Session field the catalog itself writes back to metadata.json rather than only
 ever reading (see the Session model + mutations module docstrings) — everything else there
 still mirrors what the Pi recorded.
+Phase 7 adds an editable task description, same in-place ``#detail-body`` swap as notes.
+Unlike task rename (Phase 2), a description edit doesn't affect the Tasks column or any
+other selection on the page, so it doesn't need the full-page reload rename uses — it's
+scoped to the detail pane like every Phase 6 field, just with no on-disk manifest to write
+(tasks have none; see the mutations module docstring).
 """
 
 from __future__ import annotations
@@ -72,6 +77,7 @@ from polyumi_catalog.mutations import (
     set_scene_notes,
     set_session_notes,
     set_session_unusable,
+    set_task_description,
 )
 from polyumi_catalog.sync import sync_datasets, sync_recordings
 
@@ -224,6 +230,16 @@ def create_app(engine: Engine, recordings_dir: pathlib.Path | None = None) -> Fa
             except MutationError as err:
                 return PlainTextResponse(str(err), status_code=400)
         return RedirectResponse('/', status_code=303)
+
+    @app.post('/tasks/{task_id}/description', response_class=HTMLResponse)
+    def post_task_description(request: Request, task_id: int, description: str = Form('')) -> HTMLResponse:
+        with DBSession(engine) as db:
+            try:
+                set_task_description(db, task_id, description)
+            except MutationError as err:
+                return PlainTextResponse(str(err), status_code=400)
+            detail = queries.task_detail(db, str(task_id))
+        return render(request, '_detail.html', detail=detail, oob=False)
 
     @app.post('/scenes/{scene_id}/task')
     def post_assign_scene_task(scene_id: str, task_id: str = Form('')):

--- a/catalog/polyumi_catalog/app.py
+++ b/catalog/polyumi_catalog/app.py
@@ -40,6 +40,11 @@ Phase 5 adds marking an episode unusable (excluded from dataset exports): a plai
 from the session detail pane, same in-place-swap style as MCAP export, except it also
 out-of-band-updates the Episodes column (``_detail_with_episodes_oob``) so that column's
 grey-out reflects the change immediately without requiring the scene to be reselected.
+Phase 6 adds editable notes for both scenes and sessions: an HTMX form POST that re-swaps
+``#detail-body`` in place, same style as every other detail-pane mutation. Session notes is
+the first Session field the catalog itself writes back to metadata.json rather than only
+ever reading (see the Session model + mutations module docstrings) — everything else there
+still mirrors what the Pi recorded.
 """
 
 from __future__ import annotations
@@ -59,7 +64,15 @@ from polyumi_catalog.db import default_datasets_dir
 from polyumi_catalog.dataset_builder import DatasetBuildError, build_dataset
 from polyumi_catalog.models import Scene
 from polyumi_catalog.models import Session as SessionRow
-from polyumi_catalog.mutations import MutationError, assign_scene_task, create_task, rename_task, set_session_unusable
+from polyumi_catalog.mutations import (
+    MutationError,
+    assign_scene_task,
+    create_task,
+    rename_task,
+    set_scene_notes,
+    set_session_notes,
+    set_session_unusable,
+)
 from polyumi_catalog.sync import sync_datasets, sync_recordings
 
 _PKG_DIR = pathlib.Path(__file__).resolve().parent
@@ -291,6 +304,26 @@ def create_app(engine: Engine, recordings_dir: pathlib.Path | None = None) -> Fa
             except mcap_tools.McapError as err:
                 return PlainTextResponse(str(err), status_code=400)
         return Response(status_code=204)
+
+    @app.post('/scenes/{scene_id}/notes', response_class=HTMLResponse)
+    def post_scene_notes(request: Request, scene_id: str, notes: str = Form('')) -> HTMLResponse:
+        with DBSession(engine) as db:
+            try:
+                set_scene_notes(db, scene_id, notes)
+            except MutationError as err:
+                return PlainTextResponse(str(err), status_code=400)
+            detail = _scene_detail_with_run_state(db, scene_id)
+        return render(request, '_detail.html', detail=detail, oob=False)
+
+    @app.post('/sessions/{session_id}/notes', response_class=HTMLResponse)
+    def post_session_notes(request: Request, session_id: str, notes: str = Form('')) -> HTMLResponse:
+        with DBSession(engine) as db:
+            try:
+                set_session_notes(db, session_id, notes)
+            except MutationError as err:
+                return PlainTextResponse(str(err), status_code=400)
+            detail = queries.session_detail(db, session_id)
+        return render(request, '_detail.html', detail=detail, oob=False)
 
     @app.post('/sessions/{session_id}/mark-unusable', response_class=HTMLResponse)
     def post_mark_unusable(session_id: str) -> HTMLResponse:

--- a/catalog/polyumi_catalog/app.py
+++ b/catalog/polyumi_catalog/app.py
@@ -36,6 +36,10 @@ is a check-then-set on that shared dict, so it's guarded by ``app.state.pp_runs_
 (a plain ``threading.Lock``) to keep two near-simultaneous POSTs (e.g. a fast double
 click before the button disables) from both passing the "not already running" check
 and starting two pipeline runs against the same scene.zarr concurrently.
+Phase 5 adds marking an episode unusable (excluded from dataset exports): a plain HTMX POST
+from the session detail pane, same in-place-swap style as MCAP export, except it also
+out-of-band-updates the Episodes column (``_detail_with_episodes_oob``) so that column's
+grey-out reflects the change immediately without requiring the scene to be reselected.
 """
 
 from __future__ import annotations
@@ -55,7 +59,7 @@ from polyumi_catalog.db import default_datasets_dir
 from polyumi_catalog.dataset_builder import DatasetBuildError, build_dataset
 from polyumi_catalog.models import Scene
 from polyumi_catalog.models import Session as SessionRow
-from polyumi_catalog.mutations import MutationError, assign_scene_task, create_task, rename_task
+from polyumi_catalog.mutations import MutationError, assign_scene_task, create_task, rename_task, set_session_unusable
 from polyumi_catalog.sync import sync_datasets, sync_recordings
 
 _PKG_DIR = pathlib.Path(__file__).resolve().parent
@@ -87,6 +91,22 @@ def create_app(engine: Engine, recordings_dir: pathlib.Path | None = None) -> Fa
         pending_scenes = queries.scenes_by_ids(db, pending_ids)
         all_tasks = queries.list_task_options(db)
         return render(request, '_dataset_builder.html', pending_scenes=pending_scenes, all_tasks=all_tasks, oob=oob)
+
+    def _detail_with_episodes_oob(db: DBSession, session_id: str) -> HTMLResponse:
+        """
+        Re-render the session detail pane plus an out-of-band update of its scene's Episodes
+        column, so a usable/unusable toggle grey-out is reflected immediately if that scene's
+        episode list happens to be open (same "update a currently-visible widget" pattern as
+        the dataset-draft builder — see the module docstring's Phase 3 paragraph).
+        """
+        detail = queries.session_detail(db, session_id)
+        detail_html = templates.env.get_template('_detail.html').render(detail=detail, oob=False)
+        if detail.get('scene_id'):
+            sessions = queries.list_sessions(db, detail['scene_id'])
+            episodes_html = templates.env.get_template('_episodes.html').render(sessions=sessions, oob=True)
+        else:
+            episodes_html = ''
+        return HTMLResponse(detail_html + episodes_html)
 
     def _scene_detail_with_run_state(db: DBSession, scene_id: str) -> dict:
         """scene_detail plus this process's live pipeline-run status, if any."""
@@ -271,6 +291,24 @@ def create_app(engine: Engine, recordings_dir: pathlib.Path | None = None) -> Fa
             except mcap_tools.McapError as err:
                 return PlainTextResponse(str(err), status_code=400)
         return Response(status_code=204)
+
+    @app.post('/sessions/{session_id}/mark-unusable', response_class=HTMLResponse)
+    def post_mark_unusable(session_id: str) -> HTMLResponse:
+        with DBSession(engine) as db:
+            try:
+                set_session_unusable(db, session_id, True)
+            except MutationError as err:
+                return PlainTextResponse(str(err), status_code=400)
+            return _detail_with_episodes_oob(db, session_id)
+
+    @app.post('/sessions/{session_id}/mark-usable', response_class=HTMLResponse)
+    def post_mark_usable(session_id: str) -> HTMLResponse:
+        with DBSession(engine) as db:
+            try:
+                set_session_unusable(db, session_id, False)
+            except MutationError as err:
+                return PlainTextResponse(str(err), status_code=400)
+            return _detail_with_episodes_oob(db, session_id)
 
     @app.post('/scenes/{scene_id}/run-pp', response_class=HTMLResponse)
     def post_run_pp(request: Request, scene_id: str) -> HTMLResponse:

--- a/catalog/polyumi_catalog/manifests.py
+++ b/catalog/polyumi_catalog/manifests.py
@@ -2,9 +2,10 @@
 Read/write helpers for the catalog's authoritative on-disk manifests.
 
 ``SceneManifest`` (``scene.json`` at a scene root) is the canonical home of a scene's
-task assignment and notes. ``DatasetManifest`` (``<name>.dataset.json`` beside an
-exported buffer) records what scenes/episodes and which code version produced a training
-dataset. See docs/catalog-ui-plan.md §3.2.
+task assignment, notes, and unusable-episode markers; it lives in ``polyumi_ingest.manifests``
+(re-exported here) because DP export needs to read it too — see that module's docstring.
+``DatasetManifest`` (``<name>.dataset.json`` beside an exported buffer) records what
+scenes/episodes and which code version produced a training dataset. See docs/catalog-ui-plan.md §3.2.
 """
 
 from __future__ import annotations
@@ -14,54 +15,14 @@ import pathlib
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 
-SCENE_MANIFEST_NAME = 'scene.json'
+from polyumi_ingest.manifests import SCENE_MANIFEST_NAME, SceneManifest
 
-
-@dataclass
-class SceneManifest:
-    """Authoritative scene-level metadata stored at ``<scene>/scene.json``."""
-
-    scene_id: str
-    task: str | None = None
-    notes: str | None = None
-    file_version: int = 1
-
-    @classmethod
-    def from_scene_dir(cls, scene_dir: pathlib.Path) -> SceneManifest | None:
-        """Load the manifest for ``scene_dir``, or return ``None`` if absent."""
-        path = scene_dir / SCENE_MANIFEST_NAME
-        if not path.is_file():
-            return None
-        return cls.from_file(path)
-
-    @classmethod
-    def from_file(cls, path: pathlib.Path) -> SceneManifest:
-        """Load a manifest from an explicit ``scene.json`` path."""
-        data = json.loads(path.read_text())
-        version = data.get('file_version', 1)
-        if version != 1:
-            raise ValueError(f'Unsupported scene.json file_version: {version}')
-        return cls(
-            scene_id=data['scene_id'],
-            task=data.get('task'),
-            notes=data.get('notes'),
-            file_version=version,
-        )
-
-    def to_dict(self) -> dict:
-        """Serialize to a plain dict for JSON output."""
-        return {
-            'scene_id': self.scene_id,
-            'task': self.task,
-            'notes': self.notes,
-            'file_version': self.file_version,
-        }
-
-    def write_to_scene_dir(self, scene_dir: pathlib.Path) -> pathlib.Path:
-        """Write this manifest to ``<scene_dir>/scene.json`` and return the path."""
-        path = scene_dir / SCENE_MANIFEST_NAME
-        path.write_text(json.dumps(self.to_dict(), indent=2))
-        return path
+__all__ = [
+    'SCENE_MANIFEST_NAME',
+    'SceneManifest',
+    'DatasetMemberSpec',
+    'DatasetManifest',
+]
 
 
 @dataclass

--- a/catalog/polyumi_catalog/models.py
+++ b/catalog/polyumi_catalog/models.py
@@ -49,11 +49,13 @@ class Session(SQLModel, table=True):
     """
     A single recording session (one demo episode or a mapping pass).
 
-    Mirrors the session's ``metadata.json``, except ``unusable`` which caches the scene's
-    ``scene.json`` (``unusable_episodes``, keyed by session directory name) — same
-    cache-of-the-manifest pattern as ``Scene.task_id``/``Scene.notes``. ``task_meta`` preserves
-    the session's own collection-time task string so the UI can flag it when it disagrees with
-    the canonical scene-level task.
+    Mirrors the session's ``metadata.json`` — including ``notes``, which the catalog UI can
+    now edit in place (rewriting metadata.json), not just the Pi at record time — except
+    ``unusable``, which caches the scene's ``scene.json`` (``unusable_episodes``, keyed by
+    session directory name) instead, same cache-of-the-manifest pattern as
+    ``Scene.task_id``/``Scene.notes``. ``task_meta`` preserves the session's own
+    collection-time task string so the UI can flag it when it disagrees with the canonical
+    scene-level task.
     """
 
     session_id: str = Field(primary_key=True)
@@ -66,6 +68,7 @@ class Session(SQLModel, table=True):
     n_video_frames: int | None = None
     video_dropped_frames: int | None = None
     unusable: bool = False
+    notes: str | None = None
     created_at: datetime | None = None
 
 

--- a/catalog/polyumi_catalog/models.py
+++ b/catalog/polyumi_catalog/models.py
@@ -49,9 +49,11 @@ class Session(SQLModel, table=True):
     """
     A single recording session (one demo episode or a mapping pass).
 
-    Read-only mirror of the session's ``metadata.json``. ``task_meta`` preserves the
-    session's own collection-time task string so the UI can flag it when it disagrees
-    with the canonical scene-level task.
+    Mirrors the session's ``metadata.json``, except ``unusable`` which caches the scene's
+    ``scene.json`` (``unusable_episodes``, keyed by session directory name) — same
+    cache-of-the-manifest pattern as ``Scene.task_id``/``Scene.notes``. ``task_meta`` preserves
+    the session's own collection-time task string so the UI can flag it when it disagrees with
+    the canonical scene-level task.
     """
 
     session_id: str = Field(primary_key=True)
@@ -63,6 +65,7 @@ class Session(SQLModel, table=True):
     duration_s: float | None = None
     n_video_frames: int | None = None
     video_dropped_frames: int | None = None
+    unusable: bool = False
     created_at: datetime | None = None
 
 

--- a/catalog/polyumi_catalog/mutations.py
+++ b/catalog/polyumi_catalog/mutations.py
@@ -17,7 +17,7 @@ from sqlmodel import Session as DBSession
 from sqlmodel import select
 
 from polyumi_catalog.manifests import SceneManifest
-from polyumi_catalog.models import Scene, Task
+from polyumi_catalog.models import Scene, Session, Task
 
 
 class MutationError(ValueError):
@@ -73,6 +73,36 @@ def rename_task(db: DBSession, task_id: int, new_name: str) -> Task:
     db.commit()
     db.refresh(task)
     return task
+
+
+def _write_session_unusable(scene: Scene, session_dir_name: str, unusable: bool) -> None:
+    """Rewrite ``scene.json`` for ``scene``, adding/removing ``session_dir_name`` from the unusable set."""
+    scene_dir = pathlib.Path(scene.dir)
+    manifest = SceneManifest.from_scene_dir(scene_dir) or SceneManifest(scene_id=scene.scene_id)
+    unusable_dirs = set(manifest.unusable_episodes)
+    if unusable:
+        unusable_dirs.add(session_dir_name)
+    else:
+        unusable_dirs.discard(session_dir_name)
+    manifest.unusable_episodes = sorted(unusable_dirs)
+    manifest.write_to_scene_dir(scene_dir)
+
+
+def set_session_unusable(db: DBSession, session_id: str, unusable: bool) -> Session:
+    """Mark a session's episode usable/unusable, writing scene.json + the DB row."""
+    session = db.get(Session, session_id)
+    if session is None:
+        raise MutationError(f'No such session: {session_id}')
+    scene = db.get(Scene, session.scene_id)
+    if scene is None:
+        raise MutationError(f'No such scene: {session.scene_id}')
+
+    _write_session_unusable(scene, pathlib.Path(session.dir).name, unusable)
+    session.unusable = unusable
+    db.add(session)
+    db.commit()
+    db.refresh(session)
+    return session
 
 
 def assign_scene_task(db: DBSession, scene_id: str, task_id: int | None) -> Scene:

--- a/catalog/polyumi_catalog/mutations.py
+++ b/catalog/polyumi_catalog/mutations.py
@@ -15,6 +15,7 @@ round-trips through _get_or_create_task.
 from __future__ import annotations
 
 import pathlib
+import threading
 
 from polyumi_pi.files.metadata import SessionMetadata
 from sqlmodel import Session as DBSession
@@ -23,17 +24,33 @@ from sqlmodel import select
 from polyumi_catalog.manifests import SceneManifest
 from polyumi_catalog.models import Scene, Session, Task
 
+# Every scene.json mutation is a read-modify-write of the same file, so two near-simultaneous
+# writes to the *same* scene (e.g. marking several episodes unusable back-to-back) could
+# otherwise interleave and clobber one another. One process-wide lock serializes them, same
+# "guard a check/read-then-write against a fast double" rationale as app.state.pp_runs_lock.
+_SCENE_JSON_LOCK = threading.Lock()
+
 
 class MutationError(ValueError):
     """A mutation was rejected due to invalid input (e.g. a duplicate task name)."""
 
 
+def _load_scene_manifest(scene: Scene) -> SceneManifest:
+    """Load ``scene``'s scene.json, or a fresh default manifest if it doesn't exist yet."""
+    return SceneManifest.from_scene_dir(pathlib.Path(scene.dir)) or SceneManifest(scene_id=scene.scene_id)
+
+
+def _clean_notes(notes: str | None) -> str | None:
+    """Strip ``notes``, collapsing a blank/whitespace-only value to ``None``."""
+    return notes.strip() or None if notes is not None else None
+
+
 def _write_scene_task(scene: Scene, task_name: str | None) -> None:
     """Rewrite ``scene.json`` for ``scene`` with a new task name, preserving its other fields."""
-    scene_dir = pathlib.Path(scene.dir)
-    manifest = SceneManifest.from_scene_dir(scene_dir) or SceneManifest(scene_id=scene.scene_id)
-    manifest.task = task_name
-    manifest.write_to_scene_dir(scene_dir)
+    with _SCENE_JSON_LOCK:
+        manifest = _load_scene_manifest(scene)
+        manifest.task = task_name
+        manifest.write_to_scene_dir(pathlib.Path(scene.dir))
 
 
 def create_task(db: DBSession, name: str, description: str | None = None) -> Task:
@@ -80,16 +97,24 @@ def rename_task(db: DBSession, task_id: int, new_name: str) -> Task:
 
 
 def _write_session_unusable(scene: Scene, session_dir_name: str, unusable: bool) -> None:
-    """Rewrite ``scene.json`` for ``scene``, adding/removing ``session_dir_name`` from the unusable set."""
-    scene_dir = pathlib.Path(scene.dir)
-    manifest = SceneManifest.from_scene_dir(scene_dir) or SceneManifest(scene_id=scene.scene_id)
-    unusable_dirs = set(manifest.unusable_episodes)
-    if unusable:
-        unusable_dirs.add(session_dir_name)
-    else:
-        unusable_dirs.discard(session_dir_name)
-    manifest.unusable_episodes = sorted(unusable_dirs)
-    manifest.write_to_scene_dir(scene_dir)
+    """
+    Rewrite ``scene.json`` for ``scene``, adding/removing ``session_dir_name`` from the unusable set.
+
+    Keyed by the session directory's basename rather than its session_id: session directories
+    are immutable once synced (see app.py's thumbnail-caching comment for the same invariant),
+    so the name is stable, and DP export (buffer.py) only has the directory name available on
+    the pzarr episode group, not the session_id.
+    """
+    with _SCENE_JSON_LOCK:
+        scene_dir = pathlib.Path(scene.dir)
+        manifest = _load_scene_manifest(scene)
+        unusable_dirs = set(manifest.unusable_episodes)
+        if unusable:
+            unusable_dirs.add(session_dir_name)
+        else:
+            unusable_dirs.discard(session_dir_name)
+        manifest.unusable_episodes = sorted(unusable_dirs)
+        manifest.write_to_scene_dir(scene_dir)
 
 
 def set_session_unusable(db: DBSession, session_id: str, unusable: bool) -> Session:
@@ -114,12 +139,12 @@ def set_scene_notes(db: DBSession, scene_id: str, notes: str | None) -> Scene:
     scene = db.get(Scene, scene_id)
     if scene is None:
         raise MutationError(f'No such scene: {scene_id}')
-    notes = notes.strip() or None if notes is not None else None
+    notes = _clean_notes(notes)
 
-    scene_dir = pathlib.Path(scene.dir)
-    manifest = SceneManifest.from_scene_dir(scene_dir) or SceneManifest(scene_id=scene.scene_id)
-    manifest.notes = notes
-    manifest.write_to_scene_dir(scene_dir)
+    with _SCENE_JSON_LOCK:
+        manifest = _load_scene_manifest(scene)
+        manifest.notes = notes
+        manifest.write_to_scene_dir(pathlib.Path(scene.dir))
 
     scene.notes = notes
     db.add(scene)
@@ -139,10 +164,13 @@ def set_session_notes(db: DBSession, session_id: str, notes: str | None) -> Sess
     session = db.get(Session, session_id)
     if session is None:
         raise MutationError(f'No such session: {session_id}')
-    notes = notes.strip() or None if notes is not None else None
+    notes = _clean_notes(notes)
 
     meta_path = pathlib.Path(session.dir) / 'metadata.json'
-    meta = SessionMetadata.from_file(meta_path)
+    try:
+        meta = SessionMetadata.from_file(meta_path)
+    except FileNotFoundError:
+        raise MutationError(f'metadata.json missing on disk for session: {session_id}') from None
     meta.notes = notes
     meta.to_file()
 

--- a/catalog/polyumi_catalog/mutations.py
+++ b/catalog/polyumi_catalog/mutations.py
@@ -1,18 +1,22 @@
 """
-Mutating operations for the Phase 2 catalog UI: create/rename tasks and assign scenes.
+Mutating operations for the catalog UI: tasks, scene/session assignment, notes, and flags.
 
-Every mutation writes the authoritative on-disk ``scene.json`` first, then updates
-the corresponding DB row in the same operation, per docs/catalog-ui-plan.md §3.1/§4
+Every mutation writes the authoritative on-disk file first (``scene.json`` for
+scene-level fields, a session's own ``metadata.json`` for session-level ones), then
+updates the corresponding DB row in the same operation, per docs/catalog-ui-plan.md §3.1/§4
 ("task_id on scene is a cache of what scene.json says; the writer updates both
-scene.json and the row in one operation"). Task rows themselves have no on-disk
-manifest of their own — the canonical task list is recoverable by re-syncing, since
-every scene.json.task string round-trips through _get_or_create_task.
+scene.json and the row in one operation") — session notes extend that same pattern to
+metadata.json, which used to be a Pi-record-time-only, catalog-read-only file (see the
+Session model docstring). Task rows themselves have no on-disk manifest of their own —
+the canonical task list is recoverable by re-syncing, since every scene.json.task string
+round-trips through _get_or_create_task.
 """
 
 from __future__ import annotations
 
 import pathlib
 
+from polyumi_pi.files.metadata import SessionMetadata
 from sqlmodel import Session as DBSession
 from sqlmodel import select
 
@@ -99,6 +103,50 @@ def set_session_unusable(db: DBSession, session_id: str, unusable: bool) -> Sess
 
     _write_session_unusable(scene, pathlib.Path(session.dir).name, unusable)
     session.unusable = unusable
+    db.add(session)
+    db.commit()
+    db.refresh(session)
+    return session
+
+
+def set_scene_notes(db: DBSession, scene_id: str, notes: str | None) -> Scene:
+    """Set a scene's notes, writing scene.json + the DB row. A blank/whitespace value clears them."""
+    scene = db.get(Scene, scene_id)
+    if scene is None:
+        raise MutationError(f'No such scene: {scene_id}')
+    notes = notes.strip() or None if notes is not None else None
+
+    scene_dir = pathlib.Path(scene.dir)
+    manifest = SceneManifest.from_scene_dir(scene_dir) or SceneManifest(scene_id=scene.scene_id)
+    manifest.notes = notes
+    manifest.write_to_scene_dir(scene_dir)
+
+    scene.notes = notes
+    db.add(scene)
+    db.commit()
+    db.refresh(scene)
+    return scene
+
+
+def set_session_notes(db: DBSession, session_id: str, notes: str | None) -> Session:
+    """
+    Set a session's notes, rewriting its metadata.json + the DB row.
+
+    Unlike every other Session field, notes is now catalog-editable rather than a pure
+    read-only mirror of what the Pi wrote at record time (see the Session model docstring).
+    A blank/whitespace value clears them.
+    """
+    session = db.get(Session, session_id)
+    if session is None:
+        raise MutationError(f'No such session: {session_id}')
+    notes = notes.strip() or None if notes is not None else None
+
+    meta_path = pathlib.Path(session.dir) / 'metadata.json'
+    meta = SessionMetadata.from_file(meta_path)
+    meta.notes = notes
+    meta.to_file()
+
+    session.notes = notes
     db.add(session)
     db.commit()
     db.refresh(session)

--- a/catalog/polyumi_catalog/mutations.py
+++ b/catalog/polyumi_catalog/mutations.py
@@ -40,9 +40,9 @@ def _load_scene_manifest(scene: Scene) -> SceneManifest:
     return SceneManifest.from_scene_dir(pathlib.Path(scene.dir)) or SceneManifest(scene_id=scene.scene_id)
 
 
-def _clean_notes(notes: str | None) -> str | None:
-    """Strip ``notes``, collapsing a blank/whitespace-only value to ``None``."""
-    return notes.strip() or None if notes is not None else None
+def _clean_text(text: str | None) -> str | None:
+    """Strip ``text``, collapsing a blank/whitespace-only value to ``None``."""
+    return text.strip() or None if text is not None else None
 
 
 def _write_scene_task(scene: Scene, task_name: str | None) -> None:
@@ -96,6 +96,23 @@ def rename_task(db: DBSession, task_id: int, new_name: str) -> Task:
     return task
 
 
+def set_task_description(db: DBSession, task_id: int, description: str | None) -> Task:
+    """
+    Set a task's description, writing only the DB row.
+
+    Unlike scene/session fields, tasks have no on-disk manifest of their own (see the module
+    docstring), so there's no file to rewrite here. A blank/whitespace value clears it.
+    """
+    task = db.get(Task, task_id)
+    if task is None:
+        raise MutationError(f'No such task: {task_id}')
+    task.description = _clean_text(description)
+    db.add(task)
+    db.commit()
+    db.refresh(task)
+    return task
+
+
 def _write_session_unusable(scene: Scene, session_dir_name: str, unusable: bool) -> None:
     """
     Rewrite ``scene.json`` for ``scene``, adding/removing ``session_dir_name`` from the unusable set.
@@ -139,7 +156,7 @@ def set_scene_notes(db: DBSession, scene_id: str, notes: str | None) -> Scene:
     scene = db.get(Scene, scene_id)
     if scene is None:
         raise MutationError(f'No such scene: {scene_id}')
-    notes = _clean_notes(notes)
+    notes = _clean_text(notes)
 
     with _SCENE_JSON_LOCK:
         manifest = _load_scene_manifest(scene)
@@ -164,7 +181,7 @@ def set_session_notes(db: DBSession, session_id: str, notes: str | None) -> Sess
     session = db.get(Session, session_id)
     if session is None:
         raise MutationError(f'No such session: {session_id}')
-    notes = _clean_notes(notes)
+    notes = _clean_text(notes)
 
     meta_path = pathlib.Path(session.dir) / 'metadata.json'
     try:

--- a/catalog/polyumi_catalog/queries.py
+++ b/catalog/polyumi_catalog/queries.py
@@ -293,6 +293,7 @@ def session_detail(db: DBSession, session_id: str) -> dict:
         'video_dropped_frames': s.video_dropped_frames,
         'created_at': s.created_at,
         'unusable': s.unusable,
+        'notes': s.notes,
         'pzarr_exists': pzarr_ok,
         'mcap_exists': mcap_path is not None,
         'slam': slam,

--- a/catalog/polyumi_catalog/queries.py
+++ b/catalog/polyumi_catalog/queries.py
@@ -167,6 +167,7 @@ def list_sessions(db: DBSession, scene_id: str) -> list[dict]:
                 'video_dropped_frames': s.video_dropped_frames,
                 'task_meta': s.task_meta,
                 'created_at': s.created_at,
+                'unusable': s.unusable,
                 'slam_tracking_ratio': quality['tracking_ratio'] if quality else None,
                 'slam_low_quality': quality['low_quality'] if quality else False,
             }
@@ -291,6 +292,7 @@ def session_detail(db: DBSession, session_id: str) -> dict:
         'n_video_frames': s.n_video_frames,
         'video_dropped_frames': s.video_dropped_frames,
         'created_at': s.created_at,
+        'unusable': s.unusable,
         'pzarr_exists': pzarr_ok,
         'mcap_exists': mcap_path is not None,
         'slam': slam,

--- a/catalog/polyumi_catalog/static/app.js
+++ b/catalog/polyumi_catalog/static/app.js
@@ -29,3 +29,17 @@ document.body.addEventListener('keydown', (evt) => {
 document.body.addEventListener('htmx:responseError', (evt) => {
   alert(evt.detail.xhr.responseText || 'Request failed.');
 });
+
+// 'x' toggles the currently-open episode's usable/unusable status. Looked up by id at
+// keypress time (rather than bound once) since #detail-body — and the button inside it —
+// is replaced wholesale on every htmx swap. Ignored while typing in a form field so it
+// doesn't hijack the rename/assign/dataset-name inputs elsewhere on the page.
+document.body.addEventListener('keydown', (evt) => {
+  if (evt.key.toLowerCase() !== 'x' || evt.ctrlKey || evt.metaKey || evt.altKey) return;
+  const tag = evt.target.tagName;
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+  const btn = document.getElementById('unusable-toggle-btn');
+  if (!btn) return;
+  evt.preventDefault();
+  btn.click();
+});

--- a/catalog/polyumi_catalog/static/style.css
+++ b/catalog/polyumi_catalog/static/style.css
@@ -295,6 +295,19 @@ dd {
   margin: 0.5rem 0;
 }
 
+.notes-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  margin: 0.5rem 0;
+}
+
+.notes-form textarea {
+  width: 100%;
+  resize: vertical;
+  font: inherit;
+}
+
 .mcap-actions {
   display: flex;
   align-items: center;

--- a/catalog/polyumi_catalog/static/style.css
+++ b/catalog/polyumi_catalog/static/style.css
@@ -97,6 +97,10 @@ body {
   font-style: italic;
 }
 
+.item.item-unusable {
+  opacity: 0.45;
+}
+
 .item-name {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/catalog/polyumi_catalog/sync.py
+++ b/catalog/polyumi_catalog/sync.py
@@ -161,6 +161,7 @@ def _sync_scene(db: DBSession, scene_dir: pathlib.Path, now: datetime, force: bo
     db.add(scene)
 
     # upsert sessions and record task conflicts
+    unusable_dirs = set(manifest.unusable_episodes) if manifest else set()
     seen: set[str] = set()
     for sd, meta in metas:
         seen.add(meta.session_id)
@@ -173,6 +174,7 @@ def _sync_scene(db: DBSession, scene_dir: pathlib.Path, now: datetime, force: bo
         row.duration_s = meta.duration_s
         row.n_video_frames = meta.n_video_frames
         row.video_dropped_frames = meta.video_dropped_frames
+        row.unusable = sd.name in unusable_dirs
         row.created_at = meta.created_at
         db.add(row)
         stats.sessions_upserted += 1

--- a/catalog/polyumi_catalog/sync.py
+++ b/catalog/polyumi_catalog/sync.py
@@ -175,6 +175,7 @@ def _sync_scene(db: DBSession, scene_dir: pathlib.Path, now: datetime, force: bo
         row.n_video_frames = meta.n_video_frames
         row.video_dropped_frames = meta.video_dropped_frames
         row.unusable = sd.name in unusable_dirs
+        row.notes = meta.notes
         row.created_at = meta.created_at
         db.add(row)
         stats.sessions_upserted += 1

--- a/catalog/polyumi_catalog/templates/_detail.html
+++ b/catalog/polyumi_catalog/templates/_detail.html
@@ -128,7 +128,23 @@
           {% if detail.video_dropped_frames %}<span class="warn">({{ detail.video_dropped_frames }} dropped)</span>{% endif %}
         </dd>
         <dt>Created</dt><dd>{{ detail.created_at or '—' }}</dd>
+        {% if detail.session_type == 'EPISODE' %}
+        <dt>Usable</dt>
+        <dd>
+          {% if detail.unusable %}<span class="badge warn">unusable — excluded from exports</span>
+          {% else %}yes{% endif %}
+        </dd>
+        {% endif %}
       </dl>
+      {% if detail.session_type == 'EPISODE' %}
+      <button
+        hx-post="/sessions/{{ detail.session_id }}/{{ 'mark-usable' if detail.unusable else 'mark-unusable' }}"
+        hx-target="#detail-body"
+        hx-swap="outerHTML"
+      >
+        {{ 'Mark usable' if detail.unusable else 'Mark unusable' }}
+      </button>
+      {% endif %}
       {% if detail.slam %}
       <h3>SLAM tracking quality</h3>
       <dl>

--- a/catalog/polyumi_catalog/templates/_detail.html
+++ b/catalog/polyumi_catalog/templates/_detail.html
@@ -8,12 +8,16 @@
   <p class="muted">Virtual grouping — not a real task.</p>
   {% else %}
   <dl>
-    <dt>Description</dt><dd>{{ detail.description or '—' }}</dd>
     <dt>Created</dt><dd>{{ detail.created_at or '—' }}</dd>
   </dl>
   <form class="rename-task-form" method="post" action="/tasks/{{ detail.id }}/rename">
     <input type="text" name="new_name" value="{{ detail.name }}" required />
     <button type="submit">Rename</button>
+  </form>
+  <form class="notes-form" hx-post="/tasks/{{ detail.id }}/description" hx-target="#detail-body" hx-swap="outerHTML">
+    <label for="task-description">Description</label>
+    <textarea id="task-description" name="description" rows="3" placeholder="Add description…">{{ detail.description or '' }}</textarea>
+    <button type="submit">Save description</button>
   </form>
   {% endif %}
   <dl>

--- a/catalog/polyumi_catalog/templates/_detail.html
+++ b/catalog/polyumi_catalog/templates/_detail.html
@@ -28,7 +28,6 @@
       <dl>
         <dt>Task</dt><dd>{{ detail.task_name or '(unassigned)' }}</dd>
         <dt>Directory</dt><dd class="mono">{{ detail.dir }}</dd>
-        <dt>Notes</dt><dd>{{ detail.notes or '—' }}</dd>
         <dt>Archived</dt><dd>{{ 'yes' if detail.archived else 'no' }}</dd>
         <dt>Sessions</dt><dd>{{ detail.n_episodes }} episode / {{ detail.n_sessions }} total</dd>
         <dt>Created</dt><dd>{{ detail.created_at or '—' }}</dd>
@@ -44,6 +43,11 @@
         <button type="submit">Assign</button>
       </form>
       <button hx-post="/dataset-draft/add/{{ detail.scene_id }}" hx-swap="none">Add to dataset</button>
+      <form class="notes-form" hx-post="/scenes/{{ detail.scene_id }}/notes" hx-target="#detail-body" hx-swap="outerHTML">
+        <label for="scene-notes">Notes</label>
+        <textarea id="scene-notes" name="notes" rows="3" placeholder="Add notes…">{{ detail.notes or '' }}</textarea>
+        <button type="submit">Save notes</button>
+      </form>
       {% if detail.quality.n_episodes_with_slam %}
       <h3>Episode quality</h3>
       <dl>
@@ -147,6 +151,11 @@
         {{ 'Mark usable' if detail.unusable else 'Mark unusable' }}
       </button>
       {% endif %}
+      <form class="notes-form" hx-post="/sessions/{{ detail.session_id }}/notes" hx-target="#detail-body" hx-swap="outerHTML">
+        <label for="session-notes">Notes</label>
+        <textarea id="session-notes" name="notes" rows="3" placeholder="Add notes…">{{ detail.notes or '' }}</textarea>
+        <button type="submit">Save notes</button>
+      </form>
       {% if detail.slam %}
       <h3>SLAM tracking quality</h3>
       <dl>

--- a/catalog/polyumi_catalog/templates/_detail.html
+++ b/catalog/polyumi_catalog/templates/_detail.html
@@ -138,9 +138,11 @@
       </dl>
       {% if detail.session_type == 'EPISODE' %}
       <button
+        id="unusable-toggle-btn"
         hx-post="/sessions/{{ detail.session_id }}/{{ 'mark-usable' if detail.unusable else 'mark-unusable' }}"
         hx-target="#detail-body"
         hx-swap="outerHTML"
+        title="Shortcut: X"
       >
         {{ 'Mark usable' if detail.unusable else 'Mark unusable' }}
       </button>

--- a/catalog/polyumi_catalog/templates/_episodes.html
+++ b/catalog/polyumi_catalog/templates/_episodes.html
@@ -4,7 +4,7 @@
   {% endif %}
   {% for s in sessions %}
   <div
-    class="item"
+    class="item{% if s.unusable %} item-unusable{% endif %}"
     role="button"
     tabindex="0"
     hx-get="/select/session/{{ s.session_id }}"
@@ -15,6 +15,7 @@
     <span class="item-name" title="{{ s.name }}">{{ s.name }}</span>
     <span class="badges">
       <span class="badge type-{{ s.session_type | lower }}">{{ s.session_type }}</span>
+      {% if s.unusable %}<span class="badge warn" title="excluded from dataset exports">unusable</span>{% endif %}
       {% if s.video_dropped_frames %}<span class="badge warn" title="dropped video frames">⚠ {{ s.video_dropped_frames }}</span>{% endif %}
       {% if s.slam_tracking_ratio is not none %}
       <span class="badge{% if s.slam_low_quality %} warn{% endif %}" title="SLAM tracking ratio">

--- a/catalog/test/test_app.py
+++ b/catalog/test/test_app.py
@@ -236,6 +236,28 @@ def test_post_rename_task_cascades_and_redirects(tmp_path: pathlib.Path):
     assert manifest.task == 'fold_towel_v2'
 
 
+def test_post_task_description_saves_and_shows_in_textarea(tmp_path: pathlib.Path):
+    """POST /tasks/{id}/description updates the task row and shows the new text on re-render."""
+    rec, engine = _seed(tmp_path)
+    with DBSession(engine) as db:
+        task_id = db.exec(select(Task).where(Task.name == 'fold_towel')).first().id
+
+    client = TestClient(create_app(engine, recordings_dir=rec))
+    resp = client.post(f'/tasks/{task_id}/description', data={'description': 'Fold in half, then in half again.'})
+    assert resp.status_code == 200
+    assert 'Fold in half, then in half again.</textarea>' in resp.text
+
+    with DBSession(engine) as db:
+        assert db.get(Task, task_id).description == 'Fold in half, then in half again.'
+
+
+def test_post_task_description_unknown_task_returns_400(tmp_path: pathlib.Path):
+    """Saving a description for a nonexistent task is rejected, not a crash."""
+    rec, engine = _seed(tmp_path)
+    resp = TestClient(create_app(engine, recordings_dir=rec)).post('/tasks/999/description', data={'description': 'hi'})
+    assert resp.status_code == 400
+
+
 def _session_id(rec: pathlib.Path) -> str:
     from polyumi_pi.files.metadata import SessionMetadata as SM
 

--- a/catalog/test/test_app.py
+++ b/catalog/test/test_app.py
@@ -307,6 +307,38 @@ def test_open_foxglove_without_mcap_returns_400(tmp_path: pathlib.Path):
     assert resp.status_code == 400
 
 
+def test_mark_unusable_then_usable_round_trip(tmp_path: pathlib.Path):
+    """Marking a session unusable then usable toggles the badge, scene.json, and the DB row."""
+    rec, engine = _seed(tmp_path)
+    client = TestClient(create_app(engine, recordings_dir=rec))
+    session_id = _session_id(rec)
+
+    resp = client.post(f'/sessions/{session_id}/mark-unusable')
+    assert resp.status_code == 200
+    assert 'Mark usable' in resp.text
+    assert 'unusable — excluded from exports' in resp.text
+    # OOB episodes-column fragment is included in the same response
+    assert 'item-unusable' in resp.text
+    with DBSession(engine) as db:
+        assert db.get(Scene, 'scene-1')  # sanity: scene still resolves
+    manifest = SceneManifest.from_scene_dir(rec / 'scene_2026-07-26_10-00-00_abcd')
+    assert manifest.unusable_episodes == ['session_1']
+
+    resp = client.post(f'/sessions/{session_id}/mark-usable')
+    assert resp.status_code == 200
+    assert 'Mark unusable' in resp.text
+    assert 'item-unusable' not in resp.text
+    manifest = SceneManifest.from_scene_dir(rec / 'scene_2026-07-26_10-00-00_abcd')
+    assert manifest.unusable_episodes == []
+
+
+def test_mark_unusable_unknown_session_returns_400(tmp_path: pathlib.Path):
+    """Marking a nonexistent session id is rejected, not a crash."""
+    rec, engine = _seed(tmp_path)
+    resp = TestClient(create_app(engine, recordings_dir=rec)).post('/sessions/does-not-exist/mark-unusable')
+    assert resp.status_code == 400
+
+
 def test_index_includes_empty_dataset_builder(tmp_path: pathlib.Path):
     """With no scenes added yet, the builder shows its empty state, still offering a task picker."""
     resp = _client(tmp_path).get('/')

--- a/catalog/test/test_app.py
+++ b/catalog/test/test_app.py
@@ -307,6 +307,51 @@ def test_open_foxglove_without_mcap_returns_400(tmp_path: pathlib.Path):
     assert resp.status_code == 400
 
 
+def test_post_scene_notes_saves_and_shows_in_textarea(tmp_path: pathlib.Path):
+    """POST /scenes/{id}/notes rewrites scene.json and shows the new text on re-render."""
+    rec, engine = _seed(tmp_path)
+    client = TestClient(create_app(engine, recordings_dir=rec))
+
+    resp = client.post('/scenes/scene-1/notes', data={'notes': 'left-handed grasp'})
+    assert resp.status_code == 200
+    assert 'left-handed grasp</textarea>' in resp.text
+
+    manifest = SceneManifest.from_scene_dir(rec / 'scene_2026-07-26_10-00-00_abcd')
+    assert manifest.notes == 'left-handed grasp'
+
+
+def test_post_scene_notes_unknown_scene_returns_400(tmp_path: pathlib.Path):
+    """Saving notes for a nonexistent scene is rejected, not a crash."""
+    rec, engine = _seed(tmp_path)
+    resp = TestClient(create_app(engine, recordings_dir=rec)).post('/scenes/no-such-scene/notes', data={'notes': 'hi'})
+    assert resp.status_code == 400
+
+
+def test_post_session_notes_saves_and_shows_in_textarea(tmp_path: pathlib.Path):
+    """POST /sessions/{id}/notes rewrites metadata.json and shows the new text on re-render."""
+    rec, engine = _seed(tmp_path)
+    client = TestClient(create_app(engine, recordings_dir=rec))
+    session_id = _session_id(rec)
+
+    resp = client.post(f'/sessions/{session_id}/notes', data={'notes': 'gripper slipped'})
+    assert resp.status_code == 200
+    assert 'gripper slipped</textarea>' in resp.text
+
+    md_path = rec / 'scene_2026-07-26_10-00-00_abcd' / 'session_1' / 'metadata.json'
+    from polyumi_pi.files.metadata import SessionMetadata as SM
+
+    assert SM.from_file(md_path).notes == 'gripper slipped'
+
+
+def test_post_session_notes_unknown_session_returns_400(tmp_path: pathlib.Path):
+    """Saving notes for a nonexistent session is rejected, not a crash."""
+    rec, engine = _seed(tmp_path)
+    resp = TestClient(create_app(engine, recordings_dir=rec)).post(
+        '/sessions/does-not-exist/notes', data={'notes': 'hi'}
+    )
+    assert resp.status_code == 400
+
+
 def test_mark_unusable_then_usable_round_trip(tmp_path: pathlib.Path):
     """Marking a session unusable then usable toggles the badge, scene.json, and the DB row."""
     rec, engine = _seed(tmp_path)

--- a/catalog/test/test_manifests.py
+++ b/catalog/test/test_manifests.py
@@ -29,6 +29,25 @@ def test_scene_manifest_absent_returns_none(tmp_path: pathlib.Path):
     assert SceneManifest.from_scene_dir(scene_dir) is None
 
 
+def test_scene_manifest_unusable_episodes_round_trip(tmp_path: pathlib.Path):
+    """unusable_episodes (session dir names) survives a write/read round trip."""
+    scene_dir = tmp_path / 'scene_y'
+    scene_dir.mkdir()
+    manifest = SceneManifest(scene_id='abc-456', unusable_episodes=['session_1', 'session_3'])
+    manifest.write_to_scene_dir(scene_dir)
+
+    loaded = SceneManifest.from_scene_dir(scene_dir)
+    assert loaded.unusable_episodes == ['session_1', 'session_3']
+
+
+def test_scene_manifest_unusable_episodes_defaults_to_empty(tmp_path: pathlib.Path):
+    """A scene.json written before this field existed loads with an empty list, not a crash."""
+    path = tmp_path / 'scene.json'
+    path.write_text('{"scene_id": "abc-789", "file_version": 1}')
+    loaded = SceneManifest.from_file(path)
+    assert loaded.unusable_episodes == []
+
+
 def test_scene_manifest_rejects_unknown_version(tmp_path: pathlib.Path):
     """An unsupported file_version raises."""
     path = tmp_path / 'scene.json'

--- a/catalog/test/test_mutations.py
+++ b/catalog/test/test_mutations.py
@@ -23,6 +23,7 @@ from polyumi_catalog.mutations import (
     set_scene_notes,
     set_session_notes,
     set_session_unusable,
+    set_task_description,
 )
 from polyumi_catalog.sync import sync_recordings
 from polyumi_pi.files.metadata import SessionMetadata, SessionType
@@ -305,3 +306,29 @@ def test_rename_task_rejects_name_collision(tmp_path: pathlib.Path):
         create_task(db, 'wipe_table')
         with pytest.raises(MutationError):
             rename_task(db, a.id, 'wipe_table')
+
+
+def test_set_task_description_writes_db_row(tmp_path: pathlib.Path):
+    """Setting a task's description updates the DB row (tasks have no on-disk manifest to write)."""
+    engine = get_engine(tmp_path / 'catalog.db')
+    with DBSession(engine) as db:
+        task = create_task(db, 'fold_towel')
+        set_task_description(db, task.id, 'Fold the towel in half, then in half again.')
+        assert db.get(Task, task.id).description == 'Fold the towel in half, then in half again.'
+
+
+def test_set_task_description_blank_clears(tmp_path: pathlib.Path):
+    """A blank/whitespace-only value clears the description rather than storing an empty string."""
+    engine = get_engine(tmp_path / 'catalog.db')
+    with DBSession(engine) as db:
+        task = create_task(db, 'fold_towel', description='old description')
+        set_task_description(db, task.id, '   ')
+        assert db.get(Task, task.id).description is None
+
+
+def test_set_task_description_rejects_unknown_task(tmp_path: pathlib.Path):
+    """An unknown task_id raises MutationError instead of a crash."""
+    engine = get_engine(tmp_path / 'catalog.db')
+    with DBSession(engine) as db:
+        with pytest.raises(MutationError):
+            set_task_description(db, 999, 'hello')

--- a/catalog/test/test_mutations.py
+++ b/catalog/test/test_mutations.py
@@ -14,8 +14,8 @@ import pathlib
 import pytest
 from polyumi_catalog.db import get_engine
 from polyumi_catalog.manifests import SceneManifest
-from polyumi_catalog.models import Scene, Task
-from polyumi_catalog.mutations import MutationError, assign_scene_task, create_task, rename_task
+from polyumi_catalog.models import Scene, Session, Task
+from polyumi_catalog.mutations import MutationError, assign_scene_task, create_task, rename_task, set_session_unusable
 from polyumi_catalog.sync import sync_recordings
 from polyumi_pi.files.metadata import SessionMetadata, SessionType
 from sqlmodel import Session as DBSession
@@ -103,6 +103,54 @@ def test_assign_scene_task_rejects_unknown_ids(tmp_path: pathlib.Path):
             assign_scene_task(db, 'no-such-scene', None)
         with pytest.raises(MutationError):
             assign_scene_task(db, 'scene-3', 999)
+
+
+def test_set_session_unusable_writes_scene_json_and_survives_resync(tmp_path: pathlib.Path):
+    """Marking a session unusable rewrites scene.json; a dropped-and-resynced DB recovers it."""
+    rec = tmp_path / 'recordings'
+    scene_dir = _make_scene(rec, 'scene_2026-07-26_18-00-00_yzgh', scene_id='scene-7', task=None)
+
+    engine = get_engine(tmp_path / 'catalog.db')
+    sync_recordings(rec, engine)
+    with DBSession(engine) as db:
+        session_id = db.exec(select(Session).where(Session.scene_id == 'scene-7')).first().session_id
+        set_session_unusable(db, session_id, True)
+        assert db.get(Session, session_id).unusable is True
+
+    manifest = SceneManifest.from_scene_dir(scene_dir)
+    assert manifest.unusable_episodes == ['session_1']
+
+    rebuilt = get_engine(tmp_path / 'catalog2.db')
+    sync_recordings(rec, rebuilt)
+    with DBSession(rebuilt) as db:
+        row = db.exec(select(Session).where(Session.scene_id == 'scene-7')).first()
+        assert row.unusable is True
+
+
+def test_set_session_unusable_can_clear(tmp_path: pathlib.Path):
+    """Marking a session usable again removes it from scene.json's unusable_episodes."""
+    rec = tmp_path / 'recordings'
+    scene_dir = _make_scene(rec, 'scene_2026-07-26_19-00-00_yzij', scene_id='scene-8', task=None)
+    SceneManifest(scene_id='scene-8', unusable_episodes=['session_1']).write_to_scene_dir(scene_dir)
+
+    engine = get_engine(tmp_path / 'catalog.db')
+    sync_recordings(rec, engine)
+    with DBSession(engine) as db:
+        session_id = db.exec(select(Session).where(Session.scene_id == 'scene-8')).first().session_id
+        assert db.get(Session, session_id).unusable is True
+        set_session_unusable(db, session_id, False)
+        assert db.get(Session, session_id).unusable is False
+
+    manifest = SceneManifest.from_scene_dir(scene_dir)
+    assert manifest.unusable_episodes == []
+
+
+def test_set_session_unusable_rejects_unknown_session(tmp_path: pathlib.Path):
+    """An unknown session_id raises MutationError instead of silently no-op'ing."""
+    engine = get_engine(tmp_path / 'catalog.db')
+    with DBSession(engine) as db:
+        with pytest.raises(MutationError):
+            set_session_unusable(db, 'no-such-session', True)
 
 
 def test_rename_task_cascades_to_every_member_scene(tmp_path: pathlib.Path):

--- a/catalog/test/test_mutations.py
+++ b/catalog/test/test_mutations.py
@@ -252,6 +252,24 @@ def test_set_session_notes_rejects_unknown_session(tmp_path: pathlib.Path):
             set_session_notes(db, 'no-such-session', 'hello')
 
 
+def test_set_session_notes_rejects_missing_metadata_json(tmp_path: pathlib.Path):
+    """A synced session whose metadata.json has since vanished from disk raises MutationError, not FileNotFoundError."""
+    rec = tmp_path / 'recordings'
+    scene_dir = _make_scene(rec, 'scene_2026-07-27_14-00-00_yzst', scene_id='scene-13', task=None)
+    sd = scene_dir / 'session_1'
+
+    engine = get_engine(tmp_path / 'catalog.db')
+    sync_recordings(rec, engine)
+    with DBSession(engine) as db:
+        session_id = db.exec(select(Session).where(Session.scene_id == 'scene-13')).first().session_id
+
+    (sd / 'metadata.json').unlink()
+
+    with DBSession(engine) as db:
+        with pytest.raises(MutationError):
+            set_session_notes(db, session_id, 'hello')
+
+
 def test_rename_task_cascades_to_every_member_scene(tmp_path: pathlib.Path):
     """Renaming a task rewrites scene.json for every scene assigned to it, and only those."""
     rec = tmp_path / 'recordings'

--- a/catalog/test/test_mutations.py
+++ b/catalog/test/test_mutations.py
@@ -15,7 +15,15 @@ import pytest
 from polyumi_catalog.db import get_engine
 from polyumi_catalog.manifests import SceneManifest
 from polyumi_catalog.models import Scene, Session, Task
-from polyumi_catalog.mutations import MutationError, assign_scene_task, create_task, rename_task, set_session_unusable
+from polyumi_catalog.mutations import (
+    MutationError,
+    assign_scene_task,
+    create_task,
+    rename_task,
+    set_scene_notes,
+    set_session_notes,
+    set_session_unusable,
+)
 from polyumi_catalog.sync import sync_recordings
 from polyumi_pi.files.metadata import SessionMetadata, SessionType
 from sqlmodel import Session as DBSession
@@ -151,6 +159,97 @@ def test_set_session_unusable_rejects_unknown_session(tmp_path: pathlib.Path):
     with DBSession(engine) as db:
         with pytest.raises(MutationError):
             set_session_unusable(db, 'no-such-session', True)
+
+
+def test_set_scene_notes_writes_scene_json_and_survives_resync(tmp_path: pathlib.Path):
+    """Setting a scene's notes rewrites scene.json; a dropped-and-resynced DB recovers it."""
+    rec = tmp_path / 'recordings'
+    scene_dir = _make_scene(rec, 'scene_2026-07-27_10-00-00_yzkl', scene_id='scene-9', task=None)
+
+    engine = get_engine(tmp_path / 'catalog.db')
+    sync_recordings(rec, engine)
+    with DBSession(engine) as db:
+        set_scene_notes(db, 'scene-9', 'left-handed grasp')
+        assert db.get(Scene, 'scene-9').notes == 'left-handed grasp'
+
+    manifest = SceneManifest.from_scene_dir(scene_dir)
+    assert manifest.notes == 'left-handed grasp'
+
+    rebuilt = get_engine(tmp_path / 'catalog2.db')
+    sync_recordings(rec, rebuilt)
+    with DBSession(rebuilt) as db:
+        assert db.get(Scene, 'scene-9').notes == 'left-handed grasp'
+
+
+def test_set_scene_notes_blank_clears(tmp_path: pathlib.Path):
+    """A blank/whitespace-only value clears notes rather than storing an empty string."""
+    rec = tmp_path / 'recordings'
+    scene_dir = _make_scene(rec, 'scene_2026-07-27_11-00-00_yzmn', scene_id='scene-10', task=None)
+    SceneManifest(scene_id='scene-10', notes='old note').write_to_scene_dir(scene_dir)
+
+    engine = get_engine(tmp_path / 'catalog.db')
+    sync_recordings(rec, engine)
+    with DBSession(engine) as db:
+        set_scene_notes(db, 'scene-10', '   ')
+        assert db.get(Scene, 'scene-10').notes is None
+    assert SceneManifest.from_scene_dir(scene_dir).notes is None
+
+
+def test_set_scene_notes_rejects_unknown_scene(tmp_path: pathlib.Path):
+    """An unknown scene_id raises MutationError instead of a crash."""
+    engine = get_engine(tmp_path / 'catalog.db')
+    with DBSession(engine) as db:
+        with pytest.raises(MutationError):
+            set_scene_notes(db, 'no-such-scene', 'hello')
+
+
+def test_set_session_notes_writes_metadata_json_and_survives_resync(tmp_path: pathlib.Path):
+    """Setting a session's notes rewrites its metadata.json, preserving other fields."""
+    rec = tmp_path / 'recordings'
+    scene_dir = _make_scene(rec, 'scene_2026-07-27_12-00-00_yzop', scene_id='scene-11', task=None)
+    sd = scene_dir / 'session_1'
+
+    engine = get_engine(tmp_path / 'catalog.db')
+    sync_recordings(rec, engine)
+    with DBSession(engine) as db:
+        session_id = db.exec(select(Session).where(Session.scene_id == 'scene-11')).first().session_id
+        set_session_notes(db, session_id, 'gripper slipped mid-grasp')
+        assert db.get(Session, session_id).notes == 'gripper slipped mid-grasp'
+
+    meta = SessionMetadata.from_file(sd / 'metadata.json')
+    assert meta.notes == 'gripper slipped mid-grasp'
+    assert meta.session_type == SessionType.EPISODE  # other fields survive the rewrite
+    assert meta.scene_id == 'scene-11'
+
+    rebuilt = get_engine(tmp_path / 'catalog2.db')
+    sync_recordings(rec, rebuilt)
+    with DBSession(rebuilt) as db:
+        row = db.exec(select(Session).where(Session.scene_id == 'scene-11')).first()
+        assert row.notes == 'gripper slipped mid-grasp'
+
+
+def test_set_session_notes_blank_clears(tmp_path: pathlib.Path):
+    """A blank/whitespace-only value clears notes rather than storing an empty string."""
+    rec = tmp_path / 'recordings'
+    scene_dir = _make_scene(rec, 'scene_2026-07-27_13-00-00_yzqr', scene_id='scene-12', task=None)
+    sd = scene_dir / 'session_1'
+
+    engine = get_engine(tmp_path / 'catalog.db')
+    sync_recordings(rec, engine)
+    with DBSession(engine) as db:
+        session_id = db.exec(select(Session).where(Session.scene_id == 'scene-12')).first().session_id
+        set_session_notes(db, session_id, 'a note')
+        set_session_notes(db, session_id, '   ')
+        assert db.get(Session, session_id).notes is None
+    assert SessionMetadata.from_file(sd / 'metadata.json').notes is None
+
+
+def test_set_session_notes_rejects_unknown_session(tmp_path: pathlib.Path):
+    """An unknown session_id raises MutationError instead of a crash."""
+    engine = get_engine(tmp_path / 'catalog.db')
+    with DBSession(engine) as db:
+        with pytest.raises(MutationError):
+            set_session_notes(db, 'no-such-session', 'hello')
 
 
 def test_rename_task_cascades_to_every_member_scene(tmp_path: pathlib.Path):

--- a/catalog/test/test_queries.py
+++ b/catalog/test/test_queries.py
@@ -123,6 +123,23 @@ def test_list_sessions_and_detail_include_unusable(tmp_path: pathlib.Path):
         assert queries.session_detail(db, episode['session_id'])['unusable'] is True
 
 
+def test_session_detail_includes_notes(tmp_path: pathlib.Path):
+    """session_detail exposes the session's notes, synced from its metadata.json."""
+    engine = _populated_engine(tmp_path)
+    with DBSession(engine) as db:
+        sessions = queries.list_sessions(db, 'scene-1')
+        episode_id = next(s['session_id'] for s in sessions if s['session_type'] == 'EPISODE')
+        assert queries.session_detail(db, episode_id)['notes'] is None
+
+        row = db.get(Session, episode_id)
+        row.notes = 'gripper slipped'
+        db.add(row)
+        db.commit()
+
+    with DBSession(engine) as db:
+        assert queries.session_detail(db, episode_id)['notes'] == 'gripper slipped'
+
+
 def test_list_sessions_includes_slam_quality(tmp_path: pathlib.Path):
     """Episodes with SLAM results carry a tracking ratio and low_quality flag in the list."""
     engine = _populated_engine(tmp_path)

--- a/catalog/test/test_queries.py
+++ b/catalog/test/test_queries.py
@@ -8,6 +8,7 @@ import zarr
 from polyumi_catalog import queries
 from polyumi_catalog.db import get_engine
 from polyumi_catalog.manifests import SceneManifest
+from polyumi_catalog.models import Session
 from polyumi_catalog.sync import sync_recordings
 from polyumi_pi.files.metadata import SessionMetadata, SessionType
 from sqlmodel import Session as DBSession
@@ -99,6 +100,27 @@ def test_list_sessions_for_scene(tmp_path: pathlib.Path):
     assert {s['session_type'] for s in sessions} == {'MAPPING', 'EPISODE'}
     episode = next(s for s in sessions if s['session_type'] == 'EPISODE')
     assert episode['video_dropped_frames'] == 3
+
+
+def test_list_sessions_and_detail_include_unusable(tmp_path: pathlib.Path):
+    """Both list_sessions and session_detail expose the unusable flag once a session is marked."""
+    engine = _populated_engine(tmp_path)
+    with DBSession(engine) as db:
+        sessions = queries.list_sessions(db, 'scene-1')
+        episode = next(s for s in sessions if s['session_type'] == 'EPISODE')
+        assert episode['unusable'] is False
+        assert queries.session_detail(db, episode['session_id'])['unusable'] is False
+
+        row = db.get(Session, episode['session_id'])
+        row.unusable = True
+        db.add(row)
+        db.commit()
+
+    with DBSession(engine) as db:
+        sessions = queries.list_sessions(db, 'scene-1')
+        episode = next(s for s in sessions if s['session_type'] == 'EPISODE')
+        assert episode['unusable'] is True
+        assert queries.session_detail(db, episode['session_id'])['unusable'] is True
 
 
 def test_list_sessions_includes_slam_quality(tmp_path: pathlib.Path):

--- a/catalog/test/test_sync.py
+++ b/catalog/test/test_sync.py
@@ -15,7 +15,15 @@ from sqlmodel import Session as DBSession
 from sqlmodel import select
 
 
-def _make_session(scene_dir: pathlib.Path, name: str, *, scene_id: str, session_type: SessionType, task: str | None):
+def _make_session(
+    scene_dir: pathlib.Path,
+    name: str,
+    *,
+    scene_id: str,
+    session_type: SessionType,
+    task: str | None,
+    notes: str | None = None,
+):
     """Create a session directory with a metadata.json under scene_dir."""
     sd = scene_dir / name
     sd.mkdir(parents=True)
@@ -24,6 +32,7 @@ def _make_session(scene_dir: pathlib.Path, name: str, *, scene_id: str, session_
         scene_id=scene_id,
         session_type=session_type,
         task=task,
+        notes=notes,
         n_video_frames=100,
     )
     md.to_file()
@@ -86,6 +95,23 @@ def test_sync_populates_unusable_from_scene_json(tmp_path: pathlib.Path):
     with DBSession(engine) as db:
         sessions = {pathlib.Path(s.dir).name: s.unusable for s in db.exec(select(Session)).all()}
     assert sessions == {'session_1': False, 'session_2': True}
+
+
+def test_sync_populates_session_notes_from_metadata(tmp_path: pathlib.Path):
+    """A session's metadata.json notes field syncs onto Session.notes."""
+    rec = tmp_path / 'recordings'
+    scene_dir = rec / 'scene_2026-07-27_09-00-00_yzst'
+    scene_dir.mkdir(parents=True)
+    _make_session(
+        scene_dir, 'session_1', scene_id='scene-v', session_type=SessionType.EPISODE, task=None, notes='wobbly grip'
+    )
+    _make_session(scene_dir, 'session_2', scene_id='scene-v', session_type=SessionType.EPISODE, task=None)
+
+    engine = _engine(tmp_path)
+    sync_recordings(rec, engine)
+    with DBSession(engine) as db:
+        notes = {pathlib.Path(s.dir).name: s.notes for s in db.exec(select(Session)).all()}
+    assert notes == {'session_1': 'wobbly grip', 'session_2': None}
 
 
 def test_sync_detects_task_conflict(tmp_path: pathlib.Path):

--- a/catalog/test/test_sync.py
+++ b/catalog/test/test_sync.py
@@ -72,6 +72,22 @@ def test_sync_scene_id_falls_back_to_metadata(tmp_path: pathlib.Path):
         assert db.get(Scene, 'meta-scene') is not None
 
 
+def test_sync_populates_unusable_from_scene_json(tmp_path: pathlib.Path):
+    """A session dir listed in scene.json's unusable_episodes syncs with Session.unusable=True."""
+    rec = tmp_path / 'recordings'
+    scene_dir = rec / 'scene_2026-07-26_09-00-00_zzzz'
+    scene_dir.mkdir(parents=True)
+    SceneManifest(scene_id='scene-u', unusable_episodes=['session_2']).write_to_scene_dir(scene_dir)
+    _make_session(scene_dir, 'session_1', scene_id='scene-u', session_type=SessionType.EPISODE, task=None)
+    _make_session(scene_dir, 'session_2', scene_id='scene-u', session_type=SessionType.EPISODE, task=None)
+
+    engine = _engine(tmp_path)
+    sync_recordings(rec, engine)
+    with DBSession(engine) as db:
+        sessions = {pathlib.Path(s.dir).name: s.unusable for s in db.exec(select(Session)).all()}
+    assert sessions == {'session_1': False, 'session_2': True}
+
+
 def test_sync_detects_task_conflict(tmp_path: pathlib.Path):
     """A session whose metadata task differs from scene.json is flagged, not silently merged."""
     rec = tmp_path / 'recordings'

--- a/ingest/polyumi_ingest/export/dp/buffer.py
+++ b/ingest/polyumi_ingest/export/dp/buffer.py
@@ -65,6 +65,7 @@ from numcodecs import Blosc
 from scipy.spatial.transform import Rotation
 
 from polyumi_ingest.camera_preproc import CAMERA0_RGB_RESOLUTION, resize_camera0_rgb
+from polyumi_ingest.manifests import SceneManifest
 from polyumi_ingest.pzarr.scene_files import SceneFiles
 from polyumi_ingest.pzarr.store import arr, grp
 from polyumi_ingest.video_helpers import GoproMp4Frames, open_gopro_frames
@@ -238,6 +239,13 @@ def _append_scene_episodes(scene_path: pathlib.Path, data_grp: zarr.Group, episo
     # apart in logs/errors (otherwise every scene logs as e.g. 'scene.zarr/episode_0').
     scene_label = zarr_path.parent.name
 
+    # scene.json (not the pzarr) is the canonical home of the unusable-episode marker set from
+    # the catalog UI, so it's checked here rather than baked into pzarr at build time.
+    # zarr_path.parent is the scene root regardless of whether scene_path itself was given as
+    # the scene root or as a direct .zarr path (see resolve_zarr_path).
+    manifest = SceneManifest.from_scene_dir(zarr_path.parent)
+    unusable_dirs = set(manifest.unusable_episodes) if manifest else set()
+
     root = zarr.open_group(str(zarr_path), mode='r')
     n_episodes = int(root.attrs.get('n_episodes', 0))
     for i in range(n_episodes):
@@ -248,6 +256,9 @@ def _append_scene_episodes(scene_path: pathlib.Path, data_grp: zarr.Group, episo
         ep = zarr.open_group(str(zarr_path / ep_key), mode='r')
         if ep.attrs.get('session_type') == 'MAPPING':
             log.info(f'  {scene_label}/{ep_key}: MAPPING session, skipping.')
+            continue
+        if ep.attrs.get('session_dir') in unusable_dirs:
+            log.info(f'  {scene_label}/{ep_key}: marked unusable, skipping.')
             continue
         total += _export_episode(ep, data_grp, f'{scene_label}/{ep_key}', zarr_path)
         episode_ends.append(total)
@@ -261,7 +272,8 @@ def export_scene_to_dp(scene_path: pathlib.Path, output_path: pathlib.Path) -> i
     Poses come from ``eef/pose`` (preprocessing step 5), which has already resolved the
     optitrack-vs-slam source choice and put the trajectory on the hand frame.
 
-    Returns the number of episodes written. MAPPING sessions are skipped.
+    Returns the number of episodes written. MAPPING sessions and episodes marked unusable
+    in ``scene.json`` are skipped.
     """
     return export_scenes_to_dp([scene_path], output_path)
 
@@ -272,8 +284,9 @@ def export_scenes_to_dp(scene_paths: list[pathlib.Path], output_path: pathlib.Pa
 
     Each scene's episodes are appended in the given order, with ``episode_ends`` accumulating
     across the whole list — a multi-scene dataset is indistinguishable from a single big scene
-    to ``UmiDataset``, which only ever sees one buffer. MAPPING sessions are skipped scene by
-    scene, same as the single-scene exporter. Poses come from ``eef/pose`` (preprocessing step 5).
+    to ``UmiDataset``, which only ever sees one buffer. MAPPING sessions and episodes marked
+    unusable in ``scene.json`` are skipped scene by scene, same as the single-scene exporter.
+    Poses come from ``eef/pose`` (preprocessing step 5).
 
     Returns the total number of episodes written across all scenes.
     """

--- a/ingest/polyumi_ingest/manifests.py
+++ b/ingest/polyumi_ingest/manifests.py
@@ -1,0 +1,67 @@
+"""
+Read/write helpers for ``scene.json``, the catalog's authoritative scene-level manifest.
+
+Lives in ``ingest`` rather than ``catalog`` because DP export (``export.dp.buffer``) needs to
+read it too — to know which episodes are marked unusable — and ``ingest`` owns
+preprocessing/export while ``catalog`` only imports it (docs/catalog-ui-plan.md §10.2), never
+the other way around. ``polyumi_catalog.manifests`` re-exports ``SceneManifest`` from here so
+existing catalog call sites are unaffected.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+from dataclasses import dataclass, field
+
+SCENE_MANIFEST_NAME = 'scene.json'
+
+
+@dataclass
+class SceneManifest:
+    """Authoritative scene-level metadata stored at ``<scene>/scene.json``."""
+
+    scene_id: str
+    task: str | None = None
+    notes: str | None = None
+    unusable_episodes: list[str] = field(default_factory=list)
+    file_version: int = 1
+
+    @classmethod
+    def from_scene_dir(cls, scene_dir: pathlib.Path) -> SceneManifest | None:
+        """Load the manifest for ``scene_dir``, or return ``None`` if absent."""
+        path = scene_dir / SCENE_MANIFEST_NAME
+        if not path.is_file():
+            return None
+        return cls.from_file(path)
+
+    @classmethod
+    def from_file(cls, path: pathlib.Path) -> SceneManifest:
+        """Load a manifest from an explicit ``scene.json`` path."""
+        data = json.loads(path.read_text())
+        version = data.get('file_version', 1)
+        if version != 1:
+            raise ValueError(f'Unsupported scene.json file_version: {version}')
+        return cls(
+            scene_id=data['scene_id'],
+            task=data.get('task'),
+            notes=data.get('notes'),
+            unusable_episodes=data.get('unusable_episodes', []),
+            file_version=version,
+        )
+
+    def to_dict(self) -> dict:
+        """Serialize to a plain dict for JSON output."""
+        return {
+            'scene_id': self.scene_id,
+            'task': self.task,
+            'notes': self.notes,
+            'unusable_episodes': self.unusable_episodes,
+            'file_version': self.file_version,
+        }
+
+    def write_to_scene_dir(self, scene_dir: pathlib.Path) -> pathlib.Path:
+        """Write this manifest to ``<scene_dir>/scene.json`` and return the path."""
+        path = scene_dir / SCENE_MANIFEST_NAME
+        path.write_text(json.dumps(self.to_dict(), indent=2))
+        return path

--- a/ingest/test/test_dp_export.py
+++ b/ingest/test/test_dp_export.py
@@ -18,6 +18,7 @@ import zarr
 from scipy.spatial.transform import Rotation
 
 from polyumi_ingest.export.dp import export_scene_to_dp, export_scenes_to_dp
+from polyumi_ingest.manifests import SceneManifest
 
 RES = 224
 RATE = 59.94
@@ -174,6 +175,15 @@ def test_demo_poses_are_first_and_last_repeated(tmp_path: pathlib.Path) -> None:
 def test_skips_mapping_session(tmp_path: pathlib.Path) -> None:
     """A MAPPING-only scene has nothing to export and raises rather than writing an empty store."""
     scene = _build_scene(tmp_path, session_type='MAPPING')
+    out = tmp_path / 'buf.zarr.zip'
+    with pytest.raises(RuntimeError, match='no EPISODE sessions'):
+        export_scene_to_dp(scene, out)
+
+
+def test_skips_episode_marked_unusable_in_scene_json(tmp_path: pathlib.Path) -> None:
+    """An episode whose session dir is listed in scene.json's unusable_episodes is skipped."""
+    scene = _build_scene(tmp_path)
+    SceneManifest(scene_id='x', unusable_episodes=['session_0']).write_to_scene_dir(tmp_path)
     out = tmp_path / 'buf.zarr.zip'
     with pytest.raises(RuntimeError, match='no EPISODE sessions'):
         export_scene_to_dp(scene, out)

--- a/ingest/test/test_manifests.py
+++ b/ingest/test/test_manifests.py
@@ -1,0 +1,29 @@
+"""Round-trip tests for SceneManifest, the canonical home of scene.json (also read by DP export)."""
+
+from __future__ import annotations
+
+import pathlib
+
+from polyumi_ingest.manifests import SceneManifest
+
+
+def test_scene_manifest_round_trip(tmp_path: pathlib.Path):
+    """Writing then reading a scene manifest preserves its fields, including unusable_episodes."""
+    scene_dir = tmp_path / 'scene_x'
+    scene_dir.mkdir()
+    manifest = SceneManifest(scene_id='abc-123', task='fold_towel', notes='left-handed', unusable_episodes=['s1'])
+    manifest.write_to_scene_dir(scene_dir)
+
+    loaded = SceneManifest.from_scene_dir(scene_dir)
+    assert loaded is not None
+    assert loaded.scene_id == 'abc-123'
+    assert loaded.task == 'fold_towel'
+    assert loaded.notes == 'left-handed'
+    assert loaded.unusable_episodes == ['s1']
+
+
+def test_scene_manifest_absent_returns_none(tmp_path: pathlib.Path):
+    """A scene dir without scene.json yields None."""
+    scene_dir = tmp_path / 'scene_empty'
+    scene_dir.mkdir()
+    assert SceneManifest.from_scene_dir(scene_dir) is None


### PR DESCRIPTION
enabled marking sessions as unusable, so that they aren't included in the dataset export
added ability to leave notes on sessions and scenes

