### PR TITLE
47 gripper control

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,16 @@ bash -c 'unset VIRTUAL_ENV; cd ros2_ws && source /opt/ros/kilted/setup.bash \
   && colcon test --packages-select polyumi_ros2 \
   && colcon test-result --test-result-base build/polyumi_ros2'
 ```
+The **NUC bridges** in `nuc/` are standalone scripts, not an ament package, so `colcon test`
+never sees them. `nuc/test_fr3_gripper_bridge.py` runs on the laptop anyway — it needs only the
+`franka_msgs` message definitions (built in `ros2_ws`) and mocks the action clients, so no
+hardware or NUC is involved:
+```bash
+bash -c 'unset VIRTUAL_ENV; source /opt/ros/kilted/setup.bash \
+  && source ros2_ws/install/setup.bash \
+  && /usr/bin/python3 -m pytest nuc/test_fr3_gripper_bridge.py -q'
+```
+
 The generated `ament_copyright` / `ament_flake8` / `ament_pep257` linter tests were **deleted** —
 their ROS defaults (99 cols, ament import order) contradicted this repo's ruff config, so
 `colcon test` failed regardless of whether real tests passed. Python style is ruff's job alone;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,19 @@ camera, Foxglove, and `policy_client_node`. They interoperate over **CycloneDDS*
 ```bash
 source setup_franka_env.sh   # RMW=cyclonedds, domain 0, CYCLONEDDS_URI, 10.0.0.1 on enp0s31f6
 ```
-On the NUC: `fr3-bringup` + `fr3-arm-controller`. Full reference and the exact
+On the NUC, two launch files: `nuc/launch/fr3_bringup.launch.py` (the hardware session —
+franka_bringup + the `fr3_arm_controller` spawner, replacing the `fr3-bringup` +
+`fr3-arm-controller` alias pair) and `nuc/launch/fr3_inference.launch.py` (move_group + both
+PolyUMI bridges, with separate `execute_arm` / `execute_gripper` flags, both defaulting false).
+They are deliberately two files: bringup is the crash-prone, FCI-gated piece and must be
+restartable on its own.
+
+**`./fr3_session.sh`** (repo root) builds the whole wall — NUC, Pi, GPU box, laptop — as one
+tmux session, running the safe commands and pre-typing the robot-moving ones for you to
+confirm. Every fresh start (not a re-attach) also rsyncs `nuc/` to the NUC and runs
+`./deploy.sh` for the Pi, so both run this working copy rather than whatever they last had —
+`SKIP_DEPLOY=1` skips that for a faster re-launch. Re-run to re-attach after a disconnect; the
+NUC/GPU-box panes are remote tmux, so they survive. Full reference and the exact
 environment assumptions live in [docs/crb-fr3-inference.md](docs/crb-fr3-inference.md).
 
 **Clock sync (this setup):** the NUC and laptop must agree on wall time or TF lookups fail

--- a/deploy.sh
+++ b/deploy.sh
@@ -23,17 +23,46 @@ rsync -av --delete --mkpath \
     pi "${PI_HOST}":~/PolyUMI/
 
 echo "==> Deploying polyumi_pi_msgs to ${PI_HOST}..."
+# NB: *_pb2.py / *_pb2.pyi are deliberately NOT shipped — they are machine-specific build
+# artifacts (which is also why they're gitignored), and copying this PC's copies to the Pi
+# is an outright bug. Generated code carries a gencode-version stamp that must not be newer
+# than the importing machine's protobuf runtime, and the two machines don't agree:
+#   - this PC's ROS side runs system protobuf 4.21.12, and `colcon build` regenerates these
+#     files in-place using the system's protoc 3.5.1 -> pre-3.19 gencode, which protobuf 6.x
+#     REFUSES to load ("Descriptors cannot be created directly").
+#   - the Pi runs protobuf 6.33.6, which needs modern gencode stamped <= its own version.
+# So whichever tool ran last on the PC (colcon build vs. a uv PEP-517 build) used to decide
+# what the Pi received. Instead the Pi builds its own below, against its own runtime.
 rsync -av --delete --mkpath \
     --exclude='.venv/' \
     --exclude='*.egg-info/' \
     --exclude='__pycache__/' \
+    --exclude='*_pb2.py' \
+    --exclude='*_pb2.pyi' \
     ros2_ws/src/polyumi_pi_msgs "${PI_HOST}":~/PolyUMI/ros2_ws/src/
 
-echo "==> Syncing Pi venv..."
+echo "==> Syncing Pi venv (and regenerating protobuf bindings ON the Pi)..."
+# --reinstall-package polyumi-pi-msgs forces its PEP-517 build to re-run here, which is what
+# regenerates the *_pb2.py excluded above (setup.py's compile_protos()). Without it, uv sees
+# an already-installed editable package and skips the build, leaving the Pi with whatever
+# stale bindings it had. Costs a few seconds per deploy; correctness is worth it.
 ssh "${PI_HOST}" '
     set -euo pipefail
     [ -d ~/PolyUMI/pi/.venv ] || ~/.local/bin/uv venv --system-site-packages ~/PolyUMI/pi/.venv
-    cd ~/PolyUMI/pi && ~/.local/bin/uv sync --no-dev --frozen --extra pi
+    cd ~/PolyUMI/pi && ~/.local/bin/uv sync --no-dev --frozen --extra pi \
+        --reinstall-package polyumi-pi-msgs
+'
+
+echo "==> Verifying protobuf bindings import on the Pi..."
+# Fail the deploy here rather than at stream time: a gencode/runtime mismatch is an IMPORT
+# error, so it takes down every polyumi-pi command, not just the one you were running.
+ssh "${PI_HOST}" '
+    cd ~/PolyUMI/pi && .venv/bin/python -c "
+from polyumi_pi_msgs.audio_chunk_pb2 import AudioChunk
+from polyumi_pi_msgs.camera_frame_pb2 import CameraFrame
+import google.protobuf
+print(\"    protobuf bindings OK (runtime\", google.protobuf.__version__ + \")\")
+"
 '
 
 echo "==> Applying ALSA preset (UCM warnings about 'use case configuration' are harmless)..."

--- a/deploy.sh
+++ b/deploy.sh
@@ -46,12 +46,24 @@ echo "==> Syncing Pi venv (and regenerating protobuf bindings ON the Pi)..."
 # regenerates the *_pb2.py excluded above (setup.py's compile_protos()). Without it, uv sees
 # an already-installed editable package and skips the build, leaving the Pi with whatever
 # stale bindings it had. Costs a few seconds per deploy; correctness is worth it.
-ssh "${PI_HOST}" '
+#
+# The name is the DISTRIBUTION name (hyphens), not the import name — and uv treats an unknown
+# --reinstall-package as a silent no-op, so a typo here would quietly restore exactly the stale-
+# bindings bug this flag exists to prevent. The `uv pip show` below is the check that the name
+# still resolves to something; the import check after it is what proves the build was any good.
+PKG=polyumi-pi-msgs
+ssh "${PI_HOST}" "
     set -euo pipefail
     [ -d ~/PolyUMI/pi/.venv ] || ~/.local/bin/uv venv --system-site-packages ~/PolyUMI/pi/.venv
     cd ~/PolyUMI/pi && ~/.local/bin/uv sync --no-dev --frozen --extra pi \
-        --reinstall-package polyumi-pi-msgs
-'
+        --reinstall-package ${PKG}
+    ~/.local/bin/uv pip show --quiet ${PKG} 2>/dev/null || {
+        echo \"ERROR: '${PKG}' is not installed in the Pi venv — --reinstall-package matched\" >&2
+        echo \"       nothing, so the protobuf bindings were NOT regenerated. Has the package\" >&2
+        echo \"       name in ros2_ws/src/polyumi_pi_msgs/setup.py changed?\" >&2
+        exit 1
+    }
+"
 
 echo "==> Verifying protobuf bindings import on the Pi..."
 # Fail the deploy here rather than at stream time: a gencode/runtime mismatch is an IMPORT

--- a/docs/crb-fr3-inference.md
+++ b/docs/crb-fr3-inference.md
@@ -20,8 +20,8 @@ laptop talk to a Humble NUC. If something here drifts from reality, fix it here 
 Laptop (Kilted, Noble)                        NUC (Humble, Jammy)  [nu-crb]
 RMW=rmw_cyclonedds_cpp, DOMAIN=0  ◄─ DDS over ─►  RMW=rmw_cyclonedds_cpp, DOMAIN=0
 enp0s31f6 = 10.0.0.1/24            10.0.0.x      enx00249b860356 = 10.0.0.2/24
-  - foxglove_bridge                               - fr3-bringup (franka_bringup, arm_id:=fr3)
-  - v4l2_camera (GoPro)                           - fr3-arm-controller
+  - foxglove_bridge                               - fr3_bringup.launch.py (franka_bringup
+  - v4l2_camera (GoPro)                             + fr3_arm_controller spawner)
   - pi_receiver_node                              - move_group  (nuc/launch/fr3_move_group.launch.py)
   - policy_client_node ──HTTP──┐                  - fr3_moveit_bridge  (nuc/fr3_moveit_bridge.py)
   - dummy_server (localhost:8000) ◄┘              - fr3_gripper_bridge (nuc/fr3_gripper_bridge.py)
@@ -282,20 +282,37 @@ publishes it to `/polyumi/target_poses_preview` for Foxglove (always) and — on
 
 Start the pieces in separate terminals, in this order.
 
+> **Shortcut: `./fr3_session.sh`** builds this entire wall as one tmux session — NUC, Pi, GPU
+> box, and laptop — with the safe commands already running and the robot-moving ones typed at
+> the prompt for you to confirm. The steps below are what it automates, and remain the
+> reference for doing it by hand or debugging a pane that misbehaves. See
+> [Session launcher](#session-launcher-fr3_sessionsh).
+
 ### **1. NUC — bring up the FR3** (enable FCI on the Desk UI first):
 
 ```bash
-fr3-bringup          # franka_bringup, arm_id:=fr3, robot @ 192.168.51.20
-fr3-arm-controller   # in a second terminal: spawn the joint-trajectory controller
+ros2 launch nuc/launch/fr3_bringup.launch.py   # franka_bringup + fr3_arm_controller spawner
 ```
 
-Steps **1b** and **1c** are **only needed to actually move the arm** (the Phase 2
-`execute_motion:=true` path). The log-only inference loop skips them.
+This is the **hardware session**: `franka_bringup` plus the joint-trajectory controller
+move_group executes through. It replaces the old two-terminal `fr3-bringup` +
+`fr3-arm-controller` pair — those were only ever split because the controller spawner has to
+run *after* `controller_manager` exists, not because they are independent. (The spawner exits
+once the controller is active; it never needed a terminal of its own.) The aliases still work
+if you want the pieces separately.
 
-Both run on the NUC from a clone of this repo, in their own terminals. Each needs the
-NUC's ROS + DDS env — a non-interactive shell does **not** source `~/.bashrc`, and
+Kept deliberately separate from step 1b so it can be **restarted on its own** — this is the
+component that crashes mid-session (see [TF lookup fails](#tf-lookup-fails-fr3_link0--does-not-exist--no-tf-at-all--fr3-bringup-crashed)),
+and the one gated on enabling FCI by hand.
+
+Step **1b** is **only needed to actually move the arm** (the Phase 2
+`execute_motion:=true` path). The log-only inference loop skips it.
+
+Both launch files run on the NUC from a clone of this repo, in their own terminals. Each needs
+the NUC's ROS + DDS env — a non-interactive shell does **not** source `~/.bashrc`, and
 without `CYCLONEDDS_URI` the node comes up on the wrong RMW and is invisible to
-everything else:
+everything else (this is one reason `fr3_session.sh` opens a *tmux* on the NUC rather than
+running commands over a bare `ssh`):
 
 ```bash
 source /opt/ros/humble/setup.bash
@@ -304,13 +321,24 @@ export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
 export CYCLONEDDS_URI=file://$HOME/franka_ws/config/cyclonedds.xml
 ```
 
-#### **1b. NUC — start MoveIt `move_group`** (third NUC terminal):
+#### **1b. NUC — start the inference stack** (second NUC terminal):
 
 ```bash
-ros2 launch nuc/launch/fr3_move_group.launch.py robot_ip:=192.168.51.20
+ros2 launch nuc/launch/fr3_inference.launch.py                        # dry run, nothing moves
+ros2 launch nuc/launch/fr3_inference.launch.py execute_gripper:=true  # fingers only
+ros2 launch nuc/launch/fr3_inference.launch.py \
+    execute_arm:=true execute_gripper:=true max_velocity_scaling:=0.2
 ```
 
-This adds **only** the `move_group` planner (exposing `/move_action`,
+Starts **move_group + both PolyUMI bridges** — the three things that sit on top of the
+hardware session. They start, fail, and restart together without touching the arm's state,
+which is why they share one launch file where step 1 gets its own.
+
+**Two execute flags, not one**, and both default false: launching this file never moves the
+robot on its own. Keeping them separate is what makes the first-run-on-hardware sequence below
+possible (gripper executing, arm planning-only). The three components are described next.
+
+**move_group** adds **only** the planner (exposing `/move_action`,
 `/execute_trajectory`, `/compute_cartesian_path`) — no controllers or
 robot_state_publisher — so it runs alongside the already-up `fr3-bringup` without
 collision. Expect a harmless `No 3D sensor plugin(s) defined for octomap updates` error
@@ -334,32 +362,21 @@ Trajectory execution is managing controllers
 (Do **not** use upstream `moveit.launch.py` — it starts a *second* controller_manager +
 robot_state_publisher and collides with `fr3-bringup`.)
 
-#### **1c. NUC — start the MoveIt bridge** (fourth NUC terminal):
-
-```bash
-# from the PolyUMI repo
-python3 nuc/fr3_moveit_bridge.py --ros-args -p execute:=true -p max_velocity_scaling:=0.8
-```
-
-Subscribes `/polyumi/target_poses` (a `PoseArray` — one action chunk) and drives the local
+**`fr3_moveit_bridge`** (`execute_arm`) subscribes `/polyumi/target_poses` (a `PoseArray` — one
+action chunk) and drives the local
 move_group, planning the whole chunk as a single multi-waypoint Cartesian path.
-**`execute` defaults to `false`** (plan-only, no motion) — pass `execute:=true` to
-actually move the arm. `max_velocity_scaling` (default `0.1`, max `1.0` = the full speed
+`max_velocity_scaling` (default `0.1`, max `1.0` = the full speed
 move_group already planned at) time-scales the trajectory; **start low** (e.g. `0.1`–`0.3`)
 with a hand on the e-stop, then raise it once you trust the motion. It logs
 `move_group found (compute_cartesian_path ready).` at
-startup — if it instead says `NOT found after 10s`, step 1b isn't running.
+startup — if it instead says `NOT found after 10s`, move_group failed to come up (check the
+same launch file's output).
 
-#### **1d. NUC — start the gripper bridge** (fifth NUC terminal, only if you want the hand to move):
-
-```bash
-python3 nuc/fr3_gripper_bridge.py --ros-args -p execute:=true
-```
-
-Subscribes `/polyumi/target_gripper` (a `trajectory_msgs/JointTrajectory` — the width half of the
-action chunk) and drives `/fr3_gripper/{move,grasp}`. Like the MoveIt bridge, **`execute` defaults
-to `false`** (logs the goal it would send, commands nothing) — pass `execute:=true` to move the
-fingers. Independent of `move_group`, so it runs without steps 1b/1c.
+**`fr3_gripper_bridge`** (`execute_gripper`) subscribes `/polyumi/target_gripper` (a
+`trajectory_msgs/JointTrajectory` — the width half of the
+action chunk) and drives `/fr3_gripper/{move,grasp}`. With its flag false it logs the goal it
+would send and commands nothing. Independent of `move_group`, so it works even if move_group
+failed to start.
 
 Because the hand cannot be servoed (see [Gripper interface](#gripper-interface-franka-hand)), this
 node deliberately does **not** track every chunk: it deadbands (`width_deadband_m`, default 5 mm)
@@ -372,9 +389,10 @@ tick rather than being deadbanded away, which would otherwise park the fingers a
 never received. Parameters are validated at startup and the node refuses to start on a bad one;
 `min_command_period_s: 0` in particular used to divide by zero inside the timer callback.
 
-**First time on hardware, run the arm bridge in plan-only (`execute:=false`) and only this node
-with `execute:=true`**, so a bad width command moves fingers and nothing else. Keep the hand clear
-of objects and of the table.
+**First time on hardware, launch with `execute_gripper:=true execute_arm:=false`**, so a bad
+width command moves fingers and nothing else. Keep the hand clear of objects and of the table.
+`fr3_session.sh` pre-types this line for you but with `execute_arm:=true` — it is pre-typed,
+not run, precisely so you can edit the flags before pressing Enter.
 
 ### **2. Inference server — real (GPU box) or dummy (laptop).**
 
@@ -427,8 +445,8 @@ source install/setup.bash           # (build first if needed: colcon build)
 ros2 launch polyumi_ros2 inference_demo.launch.xml pi_host:=<raspberry pi IP address>
 # default inference_server_url is http://localhost:8000/predict_cartesian/
 # To MOVE the arm (Phase 2), add: execute_motion:=true
-#   -> publishes each action chunk on /polyumi/target_poses; needs steps 1b + 1c on the NUC.
-#   Speed is set on the BRIDGE (step 1c max_velocity_scaling), not here.
+#   -> publishes each action chunk on /polyumi/target_poses; needs step 1b on the NUC with
+#      execute_arm:=true. Speed is set there (max_velocity_scaling), not here.
 #   Chunk size is n_action_steps (default 8) -- see "Action-chunk execution" above.
 # Default is log-only: actions are logged, no pose published, arm does not move.
 # To iterate on FR3 motion alone without the Pi running, add: motion_only:=true
@@ -466,6 +484,63 @@ ros2 topic pub -1 /polyumi/target_poses geometry_msgs/msg/PoseArray \
 
 Use your measured pose with ~2 cm added to one axis (`-1` publishes once). The bridge
 should log `Executed chunk (1 waypoints).` and the arm should creep to it.
+
+### Session launcher (`fr3_session.sh`)
+
+Steps 1–4 as one tmux session, from the repo root:
+
+```bash
+./fr3_session.sh                # create, or re-attach if it is already up
+SKIP_DEPLOY=1 ./fr3_session.sh  # ...without re-syncing the NUC/Pi source trees first
+./fr3_session.sh --kill-local   # tear down the LOCAL session only (remote ones survive)
+./fr3_session.sh --kill         # --kill-local, plus stop the remote sessions too
+```
+
+Three windows: `nuc` (bringup | inference stack), `polyumi-pi` (Pi | GPU box), `laptop`.
+
+**Every fresh start (not a re-attach) deploys first.** `nuc/` is rsynced to the NUC, and
+`./deploy.sh` (see CLAUDE.md / README.md, also runnable standalone: `./deploy.sh <pi_ssh_host>`)
+is called for the Pi — so what runs on both machines matches this working copy, not whatever
+they last had checked out. Sheep is deliberately excluded: it tracks its own training branch,
+and force-syncing it would silently swap out the checkpoint code from under you.
+Skip both with `SKIP_DEPLOY=1` once you know they're already current — useful for a fast
+re-launch while iterating on the tmux layout itself rather than on NUC/Pi code. Each target is
+independent and non-fatal: an unreachable Pi (powered off, say) warns and is skipped rather
+than blocking the NUC and laptop panes from coming up.
+
+**Safe commands run; robot-moving ones are typed at the prompt and left for you to press
+Enter on.** So bringup and the Pi stream start themselves, while the inference stack (carries
+the execute flags), the policy server (carries the checkpoint path), and the laptop client
+(depends on everything above, and there is no readiness gate) wait for you. Nothing in the
+script can move the robot on its own.
+
+**The NUC and GPU-box panes run tmux on the remote host**, not a bare ssh — so a laptop sleep
+or wifi blip costs nothing (re-run the script to re-attach, everything is still running), and
+the interactive shell means `CYCLONEDDS_URI` and the `fr3-*` aliases are actually set, which a
+bare `ssh host 'cmd'` would silently skip. The Pi is a plain ssh: stateless, cheap to restart.
+Consequences worth knowing:
+
+- `--kill-local` only kills the **local** session — the NUC and GPU-box sessions survive by
+  design, for the re-attach case. `--kill` also stops those specific remote sessions
+  (`tmux kill-session`, not `kill-server`, so any unrelated session on that host is left alone).
+- Those panes are **nested tmux**, so `C-b` goes to the outer one. `C-b C-b` sends a prefix
+  through to the inner session.
+- **Re-attaching never types into a live remote pane.** The script probes each remote session
+  first and leaves the ones already running completely alone — a shell mid-bringup, or holding
+  a pre-typed line you have not pressed Enter on, is handed back untouched. (`send-keys`
+  *appends* to a readline buffer rather than replacing it, so a second pass would otherwise
+  concatenate two commands and submit the result.)
+- A host with no tmux installed, or one that is not answering, degrades to a plain `ssh` with
+  a warning rather than failing — one machine being down should not block the others. That
+  pane just will not survive a disconnect.
+
+The Pi's address is resolved from your ssh config (`ssh -G $PI_SSH_HOST`) at launch rather than
+hardcoded, since it is on DHCP and does move. `PI_SSH_HOST` defaults to `polyumi-pi` — the alias
+other users are expected to set up — so if yours is named differently, override it:
+`PI_SSH_HOST=conorpi ./fr3_session.sh`. Repo paths and URLs are further environment overrides at
+the top of the script: `NUC_REPO`, `SHEEP_REPO`, `INFERENCE_URL`, `MAX_IMAGE_AGE_S`,
+`SHELL_SETTLE_S` (raise the last one if pre-typed lines land mangled — typing races the
+remote shell's startup).
 
 ## Troubleshooting
 

--- a/docs/crb-fr3-inference.md
+++ b/docs/crb-fr3-inference.md
@@ -282,7 +282,7 @@ publishes it to `/polyumi/target_poses_preview` for Foxglove (always) and — on
 
 Start the pieces in separate terminals, in this order.
 
-**1. NUC — bring up the FR3** (enable FCI on the Desk UI first):
+### **1. NUC — bring up the FR3** (enable FCI on the Desk UI first):
 
 ```bash
 fr3-bringup          # franka_bringup, arm_id:=fr3, robot @ 192.168.51.20
@@ -304,7 +304,7 @@ export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
 export CYCLONEDDS_URI=file://$HOME/franka_ws/config/cyclonedds.xml
 ```
 
-**1b. NUC — start MoveIt `move_group`** (third NUC terminal):
+#### **1b. NUC — start MoveIt `move_group`** (third NUC terminal):
 
 ```bash
 ros2 launch nuc/launch/fr3_move_group.launch.py robot_ip:=192.168.51.20
@@ -334,7 +334,7 @@ Trajectory execution is managing controllers
 (Do **not** use upstream `moveit.launch.py` — it starts a *second* controller_manager +
 robot_state_publisher and collides with `fr3-bringup`.)
 
-**1c. NUC — start the MoveIt bridge** (fourth NUC terminal):
+#### **1c. NUC — start the MoveIt bridge** (fourth NUC terminal):
 
 ```bash
 # from the PolyUMI repo
@@ -350,7 +350,7 @@ with a hand on the e-stop, then raise it once you trust the motion. It logs
 `move_group found (compute_cartesian_path ready).` at
 startup — if it instead says `NOT found after 10s`, step 1b isn't running.
 
-**1d. NUC — start the gripper bridge** (fifth NUC terminal, only if you want the hand to move):
+#### **1d. NUC — start the gripper bridge** (fifth NUC terminal, only if you want the hand to move):
 
 ```bash
 python3 nuc/fr3_gripper_bridge.py --ros-args -p execute:=true
@@ -370,7 +370,7 @@ A quiet log with occasional goals is correct; a stream of `Command aborted!` is 
 with `execute:=true`**, so a bad width command moves fingers and nothing else. Keep the hand clear
 of objects and of the table.
 
-**2. Inference server — real (GPU box) or dummy (laptop).**
+### **2. Inference server — real (GPU box) or dummy (laptop).**
 
 *Real policy* — on the GPU workstation (`sheep`), serve a trained checkpoint. `serve_policy.sh`
 builds the image and wires the rootless-Docker flags + checkpoint/HF-cache mounts (see
@@ -401,7 +401,7 @@ with only fastapi/uvicorn/numpy — no need to source anything. The command is
 `dummy-server` (hyphen), the `[project.scripts]` entry point. Leave
 `inference_server_url` at its default (`http://localhost:8000/predict_cartesian/`) in step 4.
 
-**3. Pi — start the camera/audio stream** (ssh into the Pi):
+### **3. Pi — start the camera/audio stream** (ssh into the Pi):
 
 ```bash
 polyumi-pi stream   # ZMQ PUSH: video on :5555, audio on :5556
@@ -412,7 +412,7 @@ republishes them as `/pi/*`. Without this running, Foxglove shows no Pi feed, an
 logs a warning. (The FR3 inference loop itself doesn't depend on the Pi, but the full
 demo does.)
 
-**4. Laptop — PolyUMI ROS2 nodes + policy client** (another terminal):
+### **4. Laptop — PolyUMI ROS2 nodes + policy client** (another terminal):
 
 ```bash
 source setup_franka_env.sh          # CycloneDDS + domain 0 + bring up the fr3-link NM profile

--- a/docs/crb-fr3-inference.md
+++ b/docs/crb-fr3-inference.md
@@ -366,6 +366,12 @@ node deliberately does **not** track every chunk: it deadbands (`width_deadband_
 and rate-limits (`min_command_period_s`, default 0.25 s), sending only the latest desired width.
 A quiet log with occasional goals is correct; a stream of `Command aborted!` is not.
 
+The deadband is measured against the width the hand actually **accepted**, not the last one
+attempted — so a goal that never lands (action server gone, goal rejected) is retried on the next
+tick rather than being deadbanded away, which would otherwise park the fingers at a width they
+never received. Parameters are validated at startup and the node refuses to start on a bad one;
+`min_command_period_s: 0` in particular used to divide by zero inside the timer callback.
+
 **First time on hardware, run the arm bridge in plan-only (`execute:=false`) and only this node
 with `execute:=true`**, so a bad width command moves fingers and nothing else. Keep the hand clear
 of objects and of the table.

--- a/docs/crb-fr3-inference.md
+++ b/docs/crb-fr3-inference.md
@@ -24,9 +24,12 @@ enp0s31f6 = 10.0.0.1/24            10.0.0.x      enx00249b860356 = 10.0.0.2/24
   - v4l2_camera (GoPro)                           - fr3-arm-controller
   - pi_receiver_node                              - move_group  (nuc/launch/fr3_move_group.launch.py)
   - policy_client_node ──HTTP──┐                  - fr3_moveit_bridge  (nuc/fr3_moveit_bridge.py)
-  - dummy_server (localhost:8000) ◄┘              - publishes fr3_* TF + joint states
+  - dummy_server (localhost:8000) ◄┘              - fr3_gripper_bridge (nuc/fr3_gripper_bridge.py)
+        │                                         - publishes fr3_* TF + joint states
         │                                         - enp89s0 = 192.168.51.10 → robot @ .20
-        └── /polyumi/target_poses (PoseArray) ──────────► fr3_moveit_bridge ──► move_group
+        ├── /polyumi/target_poses (PoseArray) ─────────► fr3_moveit_bridge ──► move_group
+        └── /polyumi/target_gripper ───────────────────► fr3_gripper_bridge ─► /fr3_gripper/{move,grasp}
+              (JointTrajectory)
 ```
 
 The PolyUMI ROS2 nodes use only distro-agnostic APIs (`rclpy`, `sensor_msgs`,
@@ -135,9 +138,8 @@ Both machines must agree on all of:
   - Base frame: **`fr3_link0`**
   - EEF / tool frame: **`fr3_hand_tcp`** (tool center point, 0.1034 m past `fr3_hand`)
   - `policy_client_node` reads `base_frame` / `eef_frame` params (defaults above).
-- **Gripper:** width on `/fr3_gripper/joint_states`; action servers
-  `/fr3_gripper/{grasp,move,gripper_action,homing}`. (Wired into observations /
-  execution in Phase 2; currently a `0.0` placeholder.)
+- **Gripper (Franka Hand):** see [Gripper interface](#gripper-interface-franka-hand) below — it
+  behaves quite differently from the arm and has several traps.
 - **Robot state:** `/franka_robot_state_broadcaster/current_pose` exposes the EEF
   pose as an alternative to the TF lookup, plus joint states / wrenches.
 - **⚠ MoveIt planning group: use `fr3_arm`, NOT `fr3_manipulator`.** The SRDF defines
@@ -152,6 +154,68 @@ Both machines must agree on all of:
   `max_acceleration_scaling_factor` don't exist on the request in Humble (added later);
   setting them raises `AttributeError`. `fr3_moveit_bridge` instead scales the planned
   trajectory in time (`_slow_trajectory`) before execution.
+
+### Gripper interface (Franka Hand)
+
+Launched by `fr3-bringup` automatically — `franka.launch.py`'s `load_gripper` defaults to `true`.
+
+**It is action-only. There is no way to servo it.** `ros2 control list_hardware_interfaces` shows
+**zero** finger/gripper interfaces: the hand is not in ros2_control at all, so the native
+`cartesian_pose` command interface the arm exposes has no gripper counterpart. Nor is this a ROS
+wrapper limitation — libfranka's `franka::Gripper` (`~/franka_ws/src/libfranka/include/franka/gripper.h`)
+offers only `homing()`, `grasp()`, `move()`, `stop()`, `readOnce()`, all blocking and discrete.
+This is why PolyUMI's gripper commander is deadbanded and rate-limited rather than a streaming
+servo like UMI's — see [Phase 2.5](franka-inference-bringup.md#phase-25--gripper-control).
+
+| Interface | Type | Notes |
+|---|---|---|
+| `/fr3_gripper/move` | `franka_msgs/action/Move` | `width` (m, **full aperture**), `speed` (m/s). Position only — applies no force, stalls on contact. |
+| `/fr3_gripper/grasp` | `franka_msgs/action/Grasp` | `width`, `speed`, `force` (N), `epsilon.inner/outer`. The only action that actually **holds**: succeeds and keeps applying force if the final width lands in `[width-inner, width+outer]`. |
+| `/fr3_gripper/gripper_action` | `control_msgs/action/GripperCommand` | Convenience wrapper: auto-dispatches `move()` when opening, `grasp()` when closing. **⚠ `position` is PER-FINGER** (the node does `width = 2 * position`), unlike Move/Grasp. Speed is fixed at `default_speed_` (0.1 m/s) and epsilon at 0.005 — both unsettable through this action. Out-of-range targets `abort()` rather than clamping. |
+| `/fr3_gripper/homing` | `franka_msgs/action/Homing` | Empty goal; re-estimates max width. Needed after changing fingers. |
+| `/fr3_gripper/stop` | `std_srvs/srv/Trigger` | The sanctioned way to interrupt; action `cancel` also calls `gripper_->stop()`. |
+
+**No goal is ever rejected.** `gripper_action_server.cpp` returns `ACCEPT_AND_EXECUTE`
+unconditionally and spawns a detached `std::thread` per goal — no queue, no preemption. libfranka
+aborts the superseded command, surfacing as `goal_handle->abort()` with
+`libfranka gripper: Command aborted!`. So "latest wins" holds, but every superseded goal reports a
+failure. **Do not stream goals at the control rate.**
+
+**State:** `/fr3_gripper/joint_states`, `name: [fr3_finger_joint1, fr3_finger_joint2]`. Each finger
+reports **half** the aperture, so `width = position[0] + position[1]`. `velocity` and `effort` are
+hardcoded `0.0` — there is no real force feedback. Measured rate **~17 Hz**, not the configured 30:
+`publishGripperState()` calls the blocking `readOnce()` inside its timer callback, so the hand's UDP
+stream is the real bound. Reachable from the laptop over DDS (verified). `max_width` (~0.0817 m
+after homing) is **not published anywhere** — it exists only inside the node.
+
+### Known upstream `franka_ros2` bugs (not fixed)
+
+Both are real defects in `franka_ros2` v0.1.15, confirmed on this NUC. Neither is fixed here:
+they live in the NUC's `~/franka_ws/src/franka_ros2` checkout — **not** in our
+`external/franka_ros2` submodule, which is built for `franka_msgs` only, so patching this repo
+would change nothing at runtime. A fix means editing NUC machine state plus
+`colcon build --packages-select franka_gripper franka_bringup` and an `fr3-bringup` restart.
+Recorded so nobody re-diagnoses them.
+
+**1. The gripper's params file is silently ignored.**
+`franka_gripper/config/franka_gripper_node.yaml` is keyed `franka_gripper:`, but
+`gripper.launch.py` names the node `[arm_id, '_gripper']` = `fr3_gripper`, so the key never
+matches. Verify with `ros2 param dump /fr3_gripper`: `state_publish_rate` reads **30** (the C++
+default) rather than the YAML's 50, and `feedback_publish_rate` reads 10 rather than 30. Only
+`robot_ip` / `joint_names` take effect, because those are passed as an inline dict.
+Impact on us is small — `Move`/`Grasp` take speed and epsilon per goal, so our bridge sets what it
+needs. And fixing it would **not** raise the observed ~17 Hz state rate, which is bounded by the
+blocking `readOnce()`, not by the timer.
+
+**2. There is no finger TF.** `franka.launch.py:147` points `joint_state_publisher` at
+`franka_gripper/joint_states`, while the node actually publishes `/fr3_gripper/joint_states`
+(`ros2 topic info -v /franka_gripper/joint_states` → `Publisher count: 0`). Finger joints therefore
+never reach `robot_state_publisher`, so `fr3_leftfinger` / `fr3_rightfinger` do not resolve in TF.
+Root cause is one level up: `franka.launch.py` forwards only `robot_ip` and `use_fake_hardware` to
+`gripper.launch.py`, never `arm_id` — the gripper's own default happens to be `fr3`, so our topic
+names line up by coincidence and would break for any other `arm_id`.
+Harmless for PolyUMI because `policy_client_node` subscribes to `/fr3_gripper/joint_states`
+directly, but it will bite anyone expecting finger frames in TF.
 
 ### Quick checks
 
@@ -176,9 +240,12 @@ can't parse it. This surfaces as two loud messages:
 
 **Harmless for small/simple messages.** Verified: `ros2 topic hz /joint_states` gives a
 real rate on the laptop, TF crosses fine, and a `geometry_msgs/PoseStamped` published
-laptop→NUC arrives byte-for-byte intact. The inference loop's observation path is
-unaffected. rmw_cyclonedds 4.0.2 has no switch to suppress the type-hash emission (it
-only reads `CYCLONEDDS_URI`), so we accept this noise.
+laptop→NUC arrives byte-for-byte intact. `trajectory_msgs/JointTrajectory` (the gripper chunk on
+`/polyumi/target_gripper`) was checked the same way and also **crosses intact** — the NUC received
+`frame_id`, `joint_names`, and every point's `positions` + `time_from_start` exactly as published,
+with the `serdata.cpp:384` noise appearing alongside but not corrupting the payload. The inference
+loop's observation path is unaffected. rmw_cyclonedds 4.0.2 has no switch to suppress the type-hash
+emission (it only reads `CYCLONEDDS_URI`), so we accept this noise.
 
 **⚠ NOT harmless for large nested messages.** A `MoveGroup.Goal` sent from the **laptop**
 to the NUC's move_group fails: move_group logs `Catastrophic failure` right next to those
@@ -240,7 +307,7 @@ export CYCLONEDDS_URI=file://$HOME/franka_ws/config/cyclonedds.xml
 **1b. NUC — start MoveIt `move_group`** (third NUC terminal):
 
 ```bash
-ros2 launch <repo>/nuc/launch/fr3_move_group.launch.py robot_ip:=192.168.51.20
+ros2 launch nuc/launch/fr3_move_group.launch.py robot_ip:=192.168.51.20
 ```
 
 This adds **only** the `move_group` planner (exposing `/move_action`,
@@ -270,7 +337,8 @@ robot_state_publisher and collides with `fr3-bringup`.)
 **1c. NUC — start the MoveIt bridge** (fourth NUC terminal):
 
 ```bash
-python3 <repo>/nuc/fr3_moveit_bridge.py --ros-args -p execute:=true -p max_velocity_scaling:=0.8
+# from the PolyUMI repo
+python3 nuc/fr3_moveit_bridge.py --ros-args -p execute:=true -p max_velocity_scaling:=0.8
 ```
 
 Subscribes `/polyumi/target_poses` (a `PoseArray` — one action chunk) and drives the local
@@ -281,6 +349,26 @@ move_group already planned at) time-scales the trajectory; **start low** (e.g. `
 with a hand on the e-stop, then raise it once you trust the motion. It logs
 `move_group found (compute_cartesian_path ready).` at
 startup — if it instead says `NOT found after 10s`, step 1b isn't running.
+
+**1d. NUC — start the gripper bridge** (fifth NUC terminal, only if you want the hand to move):
+
+```bash
+python3 nuc/fr3_gripper_bridge.py --ros-args -p execute:=true
+```
+
+Subscribes `/polyumi/target_gripper` (a `trajectory_msgs/JointTrajectory` — the width half of the
+action chunk) and drives `/fr3_gripper/{move,grasp}`. Like the MoveIt bridge, **`execute` defaults
+to `false`** (logs the goal it would send, commands nothing) — pass `execute:=true` to move the
+fingers. Independent of `move_group`, so it runs without steps 1b/1c.
+
+Because the hand cannot be servoed (see [Gripper interface](#gripper-interface-franka-hand)), this
+node deliberately does **not** track every chunk: it deadbands (`width_deadband_m`, default 5 mm)
+and rate-limits (`min_command_period_s`, default 0.25 s), sending only the latest desired width.
+A quiet log with occasional goals is correct; a stream of `Command aborted!` is not.
+
+**First time on hardware, run the arm bridge in plan-only (`execute:=false`) and only this node
+with `execute:=true`**, so a bad width command moves fingers and nothing else. Keep the hand clear
+of objects and of the table.
 
 **2. Inference server — real (GPU box) or dummy (laptop).**
 
@@ -415,6 +503,23 @@ YUYV→RGB conversion (it logs "possibly slow conversion") into a ~6 MB `rgb8` m
 frame's capture stamp, so it's safe for the dry run. For **execution**, prefer a genuinely faster
 camera path (lower published resolution, or the compressed transport) so the policy isn't acting on
 200 ms-old vision.
+
+### Gripper: a stream of `Command aborted!` / "Gripper move failed"
+`franka_gripper` accepts every goal and never preempts; libfranka aborts whichever command a new
+one supersedes, so each superseded goal ends ABORTED. A steady stream of these means
+`fr3_gripper_bridge` is sending goals far too fast — check that `min_command_period_s` and
+`width_deadband_m` are actually applied (a deadband of 0 with a noisy commanded width will fire
+every period). Occasional aborts when the width changes quickly are expected and logged at info.
+
+### Gripper never moves
+In order: is `fr3_gripper_bridge` running with `execute:=true` (it defaults to false)? Does
+`ros2 action list | grep fr3_gripper` show the four servers — if not, `fr3-bringup` was started with
+`load_gripper:=false`. Is anything arriving on `/polyumi/target_gripper` (`ros2 topic hz`)? If the
+laptop publishes but the NUC sees nothing, suspect the `JointTrajectory` message crossing the
+rmw-version gap — compare against `/polyumi/target_poses`, which is known to cross fine. Finally,
+a commanded width inside `width_deadband_m` of the current one is *intentionally* not sent.
+(The `JointTrajectory` message itself is known to cross the laptop↔NUC rmw gap intact — that has
+been verified, so it is not the likely culprit.)
 
 ### First inference times out, then recovers; many actions dropped as stale
 The first `/predict_cartesian/` after the server starts includes GPU/model warmup and can exceed

--- a/docs/franka-inference-bringup.md
+++ b/docs/franka-inference-bringup.md
@@ -19,8 +19,8 @@ structural: it's two unmeasured constants, three unwired signals, and the traini
 | Latency compensation, gopro + proprio | **done** — matches UMI's scheme; unit-tested |
 | Latency compensation, finger cam + piezo | **not started** — params declared, never consumed |
 | Pose body frame (training ↔ inference) | **half** — ingest emits `hand`; robot still reports `fr3_hand_tcp` |
-| Gripper — observation | **not started** — hardcoded `0.0` |
-| Gripper — command | **not started** — `action[7]` dropped before publish |
+| Gripper — observation | **done** — Phase 2.5: `/fr3_gripper/joint_states` → `agent_pos[7]` |
+| Gripper — command | **done** — Phase 2.5: `action[7]` → `/polyumi/target_gripper` → NUC `fr3_gripper_bridge` |
 | DP export | **exists** for pose+image+gripper; no tactile; wrong schema for UMI; untested |
 | Real inference server | **in progress** — Phase 3: `serve_policy.py` verified standalone on sheep; client dry-run wiring done + unit-tested (image 224, viz preview, `/reset`); on-arm dry-run pending hardware |
 
@@ -42,10 +42,12 @@ structural: it's two unmeasured constants, three unwired signals, and the traini
      PolyUMI CAD assembly (GoPro lens faceplate → closed-fingertip midpoint), rotation an
      identity because both frames are the GoPro optical convention. Feeds every exported pose.
 
-3. **Gripper is unwired in both directions.** `_lookup_agent_pos` hardcodes
-   `gripper_width = 0.0`, so `agent_pos[7]` is a constant the policy learns nothing from; and
-   `_actions_to_pose_array` drops `action[7]`, so a commanded width goes nowhere. A
-   `PoseArray` cannot carry the width — the chunk topic needs a type that can, or a parallel one.
+3. **Gripper — RESOLVED in Phase 2.5.** Width now flows both ways: `/fr3_gripper/joint_states`
+   → `agent_pos[7]`, and `action[7]` → a parallel `trajectory_msgs/JointTrajectory` on
+   `/polyumi/target_gripper` which the NUC-side `fr3_gripper_bridge` turns into `Move`/`Grasp`
+   goals. What remains is a *calibration* gap, not a wiring one: `gripper_offset_m` (the ArUco
+   tag-separation → jaw-width offset) is taken from `gripper_calib.yaml`'s `closed_mm` and has
+   never been measured. See Phase 2.5 and open question 7.
 
 4. **The DP exporter needs a rework, and has no tests at all.** Deliberately deferred to one
    chunk of work rather than patched piecemeal, since the UMI migration rewrites this file
@@ -153,7 +155,18 @@ without remapping.
     **[0, 1]**, RGB, H=W=**224**. Not nested JSON lists: at 224×224×3×`n_obs_steps` that's
     ~1 MB/frame of JSON and too slow to encode at 10 Hz.
   - `agent_pos`: `[n_obs_steps, 8]` — `[x, y, z, qx, qy, qz, qw, gripper_width]` in robot base
-    frame (absolute). **`gripper_width` is currently always `0.0`** — see Status blocker 3.
+    frame (absolute).
+
+> **`gripper_width` on this wire is raw ArUco tag separation, not jaw aperture.** Both
+> `agent_pos[7]` and `action[7]` are in the units the *training data* uses — the x-separation of
+> the two finger tags as measured by ingest step 4 (`annotations/gripper_width/width_m`), which
+> reads ~0.005 m with the handheld gripper fully closed, not 0. The conversion to real jaw width
+> is a constant subtraction (`gripper_offset_m`) applied **client-side** by `policy_client_node`,
+> so the server never sees robot units. This mirrors UMI's calibration
+> (`get_gripper_calibration_interpolator` = `aruco_actual_width - aruco_min_width`, slope 1) — the
+> difference being that UMI applies it at dataset-generation time, so its stored data is already
+> jaw width and its inference path does no conversion at all. Moving ours into ingest is deferred
+> to the exporter rework (blocker 4).
 
 **Coordinate convention (UMI):**
 - **Observations** (`agent_pos`) are sent as **absolute** EEF coordinates in robot base frame.
@@ -272,7 +285,7 @@ print(json.dumps({
 |---|---|---|
 | `/gopro/image_raw` | `sensor_msgs/Image` | wrist camera via HDMI capture card → `v4l2_camera_node` (1920×1080@60, resized to 224×224) |
 | TF `eef_frame` → `base_frame` | via `tf2_ros.Buffer` | absolute EEF pose (xyz + quat) |
-| `/fr3_gripper/joint_states` | `sensor_msgs/JointState` | gripper width — **not implemented**, `agent_pos[7]` is hardcoded `0.0` |
+| `/fr3_gripper/joint_states` | `sensor_msgs/JointState` | gripper aperture = `position[0] + position[1]` (each finger reports half); interpolated to the frame's capture instant, offset into policy units, → `agent_pos[7]` |
 
 **Timer:** `control_hz` (10 Hz).
 
@@ -318,10 +331,15 @@ pose with a stale image against a model trained on same-instant pairs.
 | `base_frame` | `fr3_link0` | TF base frame for the EEF lookup |
 | `eef_frame` | `fr3_hand_tcp` | TF EEF/tool frame — **wrong frame**, see Status blocker 1 |
 | `execute_motion` | `false` | Off by default: the arm does not move until explicitly enabled |
+| `gripper_state_topic` | `/fr3_gripper/joint_states` | Gripper joint-state source for `agent_pos[7]` |
+| `require_gripper_state` | `false` | If true, skip the tick when no gripper state has arrived (like a TF failure). Default false so `motion_only` / no-hand setups still run, substituting the closed width with a throttled warning |
+| `gripper_offset_m` | `0.005` | ArUco tag separation → jaw aperture offset. **Never measured** — see Phase 2.5 |
+| `gripper_max_width_m` | `0.08` | Commanded widths clamp here; the FR3 hand reads ~0.0817 open |
 | `latency.gopro` | `0.0` | Camera capture→stamp delay. **Placeholder**, see Status blocker 2 |
 | `latency.finger_cam` | `0.0` | Declared, **never consumed** |
 | `latency.piezo_mic` | `0.0` | Declared, **never consumed** |
 | `latency.proprio` | `0.0` | EEF-pose measurement delay |
+| `latency.gripper` | `0.0` | Gripper-width measurement delay. UMI keeps this separate from the arm's (`gripper_action_latency` vs `robot_action_latency`); **unmeasured** |
 | `latency.arm_exec` | `0.0` | Publish→arm-moves delay; used for chunk truncation |
 | `buffers.ee_pose_s` | `1.0` | TF buffer `cache_time`; must exceed the largest compensated latency |
 
@@ -405,7 +423,94 @@ What changed vs. the original plan, and why:
 - [x] `nuc/fr3_moveit_bridge.py` implemented: plans+executes chunks via local move_group
 - [x] EEF target execution tested and verified moving the **real** robot (reduced velocity)
 - [X] full 10 Hz dummy-sine loop run end-to-end (single chunks verified; continuous loop not yet)
-- [ ] executing gripper control in addition to pose.
+- [x] executing gripper control in addition to pose — see Phase 2.5
+
+---
+
+## Phase 2.5 — Gripper control
+
+Closes Status blocker 3 and open question 7. Width flows both directions; the arm path is
+untouched.
+
+### The Franka Hand cannot be servoed — this is a hardware ceiling, not an API gap
+
+Worth stating plainly, because the obvious next instinct is to fold the gripper into Phase 4's
+streaming-servo redesign, and that is not possible.
+
+**UMI servos its gripper continuously.** `WSGController`
+(`umi/real_world/wsg_controller.py:144-250`) is a 30 Hz loop around the *same*
+`PoseTrajectoryInterpolator` the arm uses: each cycle it evaluates the interpolator, finite-
+differences a velocity, and sends `script_position_pd(position, velocity)` to a WSG50. Chunks
+arrive via `schedule_waypoint(pos, target_time)`, and `bimanual_umi_env.py:501-515` schedules every
+waypoint with a per-gripper `gripper_action_latency` distinct from `robot_action_latency`.
+
+**The Franka Hand offers nothing equivalent.** `franka::Gripper` (libfranka `gripper.h`) exposes
+exactly `homing()`, `grasp()`, `move()`, `stop()`, `readOnce()` — all blocking, all discrete. There
+is no position/velocity streaming interface at any layer, and `ros2 control
+list_hardware_interfaces` shows the hand has **zero** ros2_control interfaces (the arm's
+`cartesian_pose` interface, which Phase 4 builds on, has no gripper analogue). The ROS2 action API
+is not hiding a better path; it is the full extent of the hardware.
+
+**It also must be rate-limited.** `gripper_action_server.cpp` returns `ACCEPT_AND_EXECUTE` for
+every goal unconditionally and spawns a detached `std::thread` per goal — no queue, no preemption,
+no rejection when busy. libfranka aborts the superseded command, which the wrapper turns into
+`goal_handle->abort()`. Streaming at the 10 Hz control rate would mean ~9 spurious
+`Command aborted!` results/sec plus unbounded thread churn.
+
+So the commander is **discrete, deadbanded, and rate-limited**. That is a documented deviation from
+UMI forced by the hardware.
+
+### Width units — a pure offset, following UMI
+
+`agent_pos[7]` / `action[7]` carry raw ArUco tag separation (see the API contract note). The
+conversion to jaw aperture is a constant subtraction, matching UMI:
+`get_gripper_calibration_interpolator` (`umi/common/interpolation_util.py:36-51`) computes
+`aruco_actual_width - aruco_min_width`, and `06_generate_dataset_plan.py:136-139` passes the same
+array as both arguments — so the map has **slope 1 and no rescaling**. UMI derives the offset
+empirically as the minimum ArUco width over a calibration video in which the gripper fully closes
+(`scripts/calibrate_gripper_range.py`).
+
+Ours is currently the *declared* `closed_mm: 5.0` from `ingest/config/gripper_calib.yaml` — a value
+no code has ever read or validated. It is a ROS parameter (`gripper_offset_m`), correctable without
+a code change. A PolyUMI equivalent of UMI's calibration script is the proper fix.
+
+Note this aligns the zero point, not the stroke: the handheld gripper may open wider than the
+hand's ~0.0817 m, and commands past `gripper_max_width_m` clamp — showing up as saturation rather
+than an error.
+
+### Wiring
+
+```
+policy_client_node (laptop)                     fr3_gripper_bridge (NUC)
+  /fr3_gripper/joint_states ──► agent_pos[7]
+  action[7] ──► /polyumi/target_gripper ───────► deadband + rate limit ──► /fr3_gripper/{move,grasp}
+               (JointTrajectory)                 speed from time_from_start
+```
+
+`trajectory_msgs/JointTrajectory` because it exists identically on Kilted and Humble, is flat and
+small (so it crosses the rmw-major gap like `PoseArray` does, unlike MoveIt goals), and carries
+per-point `time_from_start` — which lets the bridge pick a lead waypoint and derive a move speed
+rather than using a fixed one. `joint_names: ['fr3_gripper_width']` is deliberately *not* a real
+joint name: the value is the full aperture, not a finger joint position.
+
+The commander is a **separate node** from `fr3_moveit_bridge` because that node's `_busy` lock
+serialises everything — a gripper command issued inside its `_on_target` would be dropped precisely
+while an arm chunk executes, i.e. during manipulation.
+
+`Move` is the default action; `Grasp` (force-controlled, the only one that actually *holds* an
+object) is opt-in via `use_grasp_below_m`, shipped disabled so bringup is pure motion.
+
+- [x] `gripper_map.py` + tests (offset conversion, clamping)
+- [x] `policy_client_node`: `/fr3_gripper/joint_states` → `agent_pos[7]`, time-interpolated
+- [x] `policy_client_node`: `action[7]` → `/polyumi/target_gripper` (+ `_preview`)
+- [x] `nuc/fr3_gripper_bridge.py`: deadbanded, rate-limited `Move`/`Grasp` commander
+- [x] `dummy_server.py`: gripper sine, 90° out of phase with X so a routing bug is visible
+- [x] `JointTrajectory` verified crossing the laptop↔NUC rmw gap intact (published from the
+      laptop, echoed on the NUC — all fields byte-for-byte; see crb-fr3-inference.md)
+- [ ] on-arm dry run (`fr3_gripper_bridge` with `execute:=false`)
+- [ ] on-arm execution (`execute:=true`, arm bridge plan-only)
+- [ ] measure `gripper_offset_m` (PolyUMI equivalent of `calibrate_gripper_range.py`)
+- [ ] measure `latency.gripper`
 
 ---
 
@@ -620,8 +725,11 @@ Franka package set present: `franka_bringup`, `franka_description`, `franka_fr3_
   template (or vendor just the interface-claiming + write loop).
 - **Confirm `MultiDOFJointTrajectory` crosses the rmw gap** (laptop Kilted 4.x ↔ NUC Humble 1.x)
   intact, like `PoseArray` does and MoveIt goals don't.
-- **Gripper** still rides separately (Q7) — the trajectory message carries pose; width needs its own
-  channel + a gripper action on the NUC.
+- **Gripper cannot join this redesign** — and not merely as a scheduling convenience. The Franka
+  Hand has **no ros2_control interface at all** and libfranka's `franka::Gripper` offers only
+  blocking `move`/`grasp`/`homing`/`stop`, so there is no gripper analogue of the `cartesian_pose`
+  command interface this stage is built on. It keeps its own channel (`/polyumi/target_gripper`)
+  and its own discrete, deadbanded commander on the NUC. See Phase 2.5.
 
 ### Checklist
 
@@ -648,8 +756,8 @@ Franka package set present: `franka_bringup`, `franka_description`, `franka_fr3_
 | 4 | Gripper width topic on Franka? | **Resolved:** `/fr3_gripper/joint_states`; actions `/fr3_gripper/{grasp,move,gripper_action,homing}`. |
 | 5 | Subprocess vs direct import for Phase 3 | **Resolved — direct import (subprocess retired).** The original answer was subprocess, but the training work produced a single Docker image whose `umi` env has both `diffusion_policy`/torch and fastapi/uvicorn, so `serve_policy.py` direct-imports the policy and the container is the isolation boundary. See Phase 3. |
 | 6 | Which physical point is the canonical `hand` frame, and what publishes it on the FR3? | **Open — blocking.** Ingest step 5 emits poses on a `hand` frame defined by `T_gopro_to_fingertip` — the closed-fingertip midpoint, measured from CAD. The FR3 must report that same point as `eef_frame`; today it reports `fr3_hand_tcp`. Needs a mounting calibration + a static TF. |
-| 7 | How do gripper width (obs) and gripper command (action) get wired? | **Open.** Obs: subscribe `/fr3_gripper/joint_states` and fill `agent_pos[7]` (currently `0.0`). Action: `PoseArray` can't carry width — either change the chunk message type or publish a parallel one, then drive `/fr3_gripper/{grasp,move}` from the NUC bridge. |
-| 8 | Do finger cam / piezo feed the policy, and at what latency? | **Open.** Params exist and are unconsumed. If they become obs, the capture instant becomes the *oldest* across streams (an observation is only as fresh as its slowest signal), and they must also be added to the DP export, which carries none of them today. |
+| 7 | How do gripper width (obs) and gripper command (action) get wired? | **Resolved — Phase 2.5.** Obs: `policy_client_node` subscribes `/fr3_gripper/joint_states` (aperture = `position[0]+position[1]`), interpolates to the frame's capture instant, offsets into policy units → `agent_pos[7]`. Action: a **parallel** `trajectory_msgs/JointTrajectory` on `/polyumi/target_gripper` (chosen over changing `PoseArray`'s type because it carries per-point timing and crosses the rmw gap), consumed by a **separate** NUC node `fr3_gripper_bridge` that deadbands + rate-limits into `Move`/`Grasp` goals. What's left is calibrating `gripper_offset_m`, not wiring. |
+| 8 | Do finger cam / piezo feed the policy, and at what latency? | **Open.** Params exist and are unconsumed. If they become obs, the capture instant becomes the *oldest* across streams (an observation is only as fresh as its slowest signal), and they must also be added to the DP export, which carries none of them today. (`latency.gripper` is now consumed — it is not in this category.) |
 | 9 | What is `latency.gopro` actually? | **Open — needs measurement, not a guess.** See Status blocker 2. |
 | 10 | How is the arm driven for smooth latency-tolerant control? | **Decided (Phase 4), not built.** Plan-then-execute (`fr3_moveit_bridge`) is the wrong model. Move to a UMI-style 1 kHz streaming Cartesian-pose `ros2_control` controller around a `PoseTrajectoryInterpolator`, using `franka_hardware`'s native `cartesian_pose` command interface (confirmed present, 1 kHz). See Phase 4. |
-| 11 | Message type for the action chunk laptop→NUC? | **Proposed (Phase 4):** `trajectory_msgs/MultiDOFJointTrajectory` (per-point transform + `time_from_start`, header stamp = `t_obs`), replacing `PoseArray` so absolute per-waypoint timing crosses. Must verify it survives the rmw-major gap. |
+| 11 | Message type for the action chunk laptop→NUC? | **Proposed (Phase 4):** `trajectory_msgs/MultiDOFJointTrajectory` (per-point transform + `time_from_start`, header stamp = `t_obs`), replacing `PoseArray` so absolute per-waypoint timing crosses. **Encouraging evidence:** Phase 2.5's `trajectory_msgs/JointTrajectory` was verified crossing the rmw-major gap intact (joint names, per-point positions and `time_from_start` all byte-for-byte), so the `trajectory_msgs` family and per-point timing are not themselves a problem. `MultiDOFJointTrajectory` is nested deeper (each point holds arrays of `Transform`/`Twist`), so it still warrants its own check. |

--- a/docs/franka-inference-bringup.md
+++ b/docs/franka-inference-bringup.md
@@ -332,7 +332,8 @@ pose with a stale image against a model trained on same-instant pairs.
 | `eef_frame` | `fr3_hand_tcp` | TF EEF/tool frame — **wrong frame**, see Status blocker 1 |
 | `execute_motion` | `false` | Off by default: the arm does not move until explicitly enabled |
 | `gripper_state_topic` | `/fr3_gripper/joint_states` | Gripper joint-state source for `agent_pos[7]` |
-| `require_gripper_state` | `false` | If true, skip the tick when no gripper state has arrived (like a TF failure). Default false so `motion_only` / no-hand setups still run, substituting the closed width with a throttled warning |
+| `require_gripper_state` | `false` | If true, skip the tick when no gripper state is available — never arrived, or gone stale. Default false so `motion_only` / no-hand setups still run: missing → closed width, stale → hold the last width, both with a throttled warning |
+| `max_gripper_age_s` | `0.5` | Age limit on the newest gripper sample. The gripper is the only observation channel that can freeze *silently* (a dead camera trips `max_image_age_s`, dead TF raises `ExtrapolationException`, but the width buffer just holds its last sample), so the age is checked explicitly. ~5x the worst observed publish interval; `<= 0` disables. Not applied under `tf_use_latest`, whose whole premise is skewed stamps |
 | `gripper_offset_m` | `0.005` | ArUco tag separation → jaw aperture offset. **Never measured** — see Phase 2.5 |
 | `gripper_max_width_m` | `0.08` | Commanded widths clamp here; the FR3 hand reads ~0.0817 open |
 | `latency.gopro` | `0.0` | Camera capture→stamp delay. **Placeholder**, see Status blocker 2 |

--- a/fr3_session.sh
+++ b/fr3_session.sh
@@ -37,10 +37,16 @@ SESSION="${SESSION:-polyumi}"
 SHELL_SETTLE_S="${SHELL_SETTLE_S:-5}"
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# Where the repo lives on each remote (verified on both hosts). Left unexpanded so the REMOTE
-# shell resolves the tilde against its own $HOME — franka on the NUC, xhy7159 on the GPU box.
-# Override from the environment if these ever move.
+
+# ssh aliases for the three remotes, and where the repo lives on each. All overridable together
+# — a host and its repo path travel as a pair, so parameterizing one without the other would let
+# you point NUC_REPO somewhere new while still ssh'ing to the old box.
+#   NUC_SSH_HOST=otherfranka NUC_REPO=~/src/PolyUMI ./fr3_session.sh
+# The repo paths are left unexpanded so the REMOTE shell resolves the tilde against its own
+# $HOME — franka on the NUC, xhy7159 on the GPU box.
+NUC_SSH_HOST="${NUC_SSH_HOST:-jailfranka}"
 NUC_REPO="${NUC_REPO:-~/Documents/PolyUMI}"
+SHEEP_SSH_HOST="${SHEEP_SSH_HOST:-sheep}"
 SHEEP_REPO="${SHEEP_REPO:-~/repos/PolyUMI}"
 
 # ssh alias for the Pi. "polyumi-pi" is the name other users are expected to set up in their
@@ -55,7 +61,7 @@ MAX_IMAGE_AGE_S="${MAX_IMAGE_AGE_S:-0.3}"
 if [ "${1:-}" = "--kill-local" ] || [ "${1:-}" = "--kill" ]; then
   tmux kill-session -t "$SESSION" 2>/dev/null && echo "Killed local session '$SESSION'."
   if [ "${1:-}" = "--kill-local" ]; then
-    echo "NOTE: the remote tmux sessions on jailfranka/sheep are still running by design."
+    echo "NOTE: the remote tmux sessions on $NUC_SSH_HOST/$SHEEP_SSH_HOST are still running by design."
     echo "      To stop those too:  ./fr3_session.sh --kill"
     exit 0
   fi
@@ -70,9 +76,9 @@ if [ "${1:-}" = "--kill-local" ] || [ "${1:-}" = "--kill" ]; then
       echo "No remote session '$sess' on $host (already gone, or host unreachable)."
     fi
   }
-  kill_remote_session jailfranka fr3-bringup
-  kill_remote_session jailfranka fr3-inference
-  kill_remote_session sheep polyumi
+  kill_remote_session "$NUC_SSH_HOST" fr3-bringup
+  kill_remote_session "$NUC_SSH_HOST" fr3-inference
+  kill_remote_session "$SHEEP_SSH_HOST" polyumi
   exit 0
 fi
 
@@ -84,13 +90,23 @@ fi
 
 # The Pi is on DHCP and its address really does change between sessions, so resolve it from the
 # ssh config rather than baking in a literal that is wrong by next week. One source of truth.
-PI_HOST="$(ssh -G "$PI_SSH_HOST" 2>/dev/null | awk '/^hostname /{print $2}')"
-if [ -z "$PI_HOST" ]; then
-  echo "ERROR: could not resolve '$PI_SSH_HOST' from your ssh config." >&2
-  echo "       Set PI_SSH_HOST to your Pi's ssh alias, e.g.: PI_SSH_HOST=conorpi ./fr3_session.sh" >&2
-  exit 1
+#
+# Checking this for emptiness would prove nothing: with no matching Host block, `ssh -G foo`
+# still exits 0 and echoes back `hostname foo`, so a typo'd alias yields a non-empty PI_HOST
+# that is just the typo — and it would then ride all the way into `pi_host:=` on the laptop's
+# launch line. Actually connecting is the only check that distinguishes the two, and it catches
+# a powered-off Pi at the same time. Non-fatal, matching how the deploy section below treats an
+# unreachable machine: one box being down should not block bringing the others up.
+PI_HOST="$(ssh -G "$PI_SSH_HOST" 2>/dev/null | awk '/^hostname /{print $2}')" || true
+if ssh -o ConnectTimeout=5 -o BatchMode=yes "$PI_SSH_HOST" true 2>/dev/null; then
+  echo "Pi resolved to $PI_HOST (ssh alias: $PI_SSH_HOST)"
+else
+  echo "WARNING: cannot reach the Pi at ssh alias '$PI_SSH_HOST' (resolved: '${PI_HOST:-nothing}')." >&2
+  echo "         Either the Pi is off, or the alias is not in your ssh config — in which case" >&2
+  echo "         ssh hands back the alias verbatim and pi_host:= below will be wrong." >&2
+  echo "         Set it with:  PI_SSH_HOST=conorpi ./fr3_session.sh" >&2
+  echo "         Continuing; the Pi panes will just fail to connect." >&2
 fi
-echo "Pi resolved to $PI_HOST (ssh alias: $PI_SSH_HOST)"
 
 # ---------------------------------------------------------------------------
 # Deploy: bring the NUC and Pi source trees in line with this working copy before anything
@@ -103,12 +119,12 @@ echo "Pi resolved to $PI_HOST (ssh alias: $PI_SSH_HOST)"
 if [ "${SKIP_DEPLOY:-0}" = 1 ]; then
   echo "SKIP_DEPLOY=1 — leaving the NUC and Pi source trees as they are."
 else
-  echo "==> Syncing nuc/ to jailfranka:$NUC_REPO ..."
+  echo "==> Syncing nuc/ to $NUC_SSH_HOST:$NUC_REPO ..."
   if rsync -a --delete --mkpath --exclude='__pycache__/' --exclude='*.pyc' \
-      nuc "jailfranka:${NUC_REPO}/"; then
+      nuc "${NUC_SSH_HOST}:${NUC_REPO}/"; then
     echo "    done."
   else
-    echo "WARNING: rsync to jailfranka failed — it may be running stale nuc/ code." >&2
+    echo "WARNING: rsync to $NUC_SSH_HOST failed — it may be running stale nuc/ code." >&2
   fi
 
   echo "==> Deploying pi/ to $PI_SSH_HOST via ./deploy.sh ..."
@@ -127,9 +143,9 @@ remote_session_exists() {
 # a pre-typed line the operator has not pressed Enter on yet — and send-keys appends to that
 # readline buffer rather than replacing it, so a second pass concatenates two commands and
 # submits the result. Re-attaching is supposed to hand the pane back exactly as it was.
-NUC_BRINGUP_FRESH=1; remote_session_exists jailfranka fr3-bringup   && NUC_BRINGUP_FRESH=0
-NUC_INFER_FRESH=1;   remote_session_exists jailfranka fr3-inference && NUC_INFER_FRESH=0
-SHEEP_FRESH=1;       remote_session_exists sheep polyumi            && SHEEP_FRESH=0
+NUC_BRINGUP_FRESH=1; remote_session_exists "$NUC_SSH_HOST" fr3-bringup   && NUC_BRINGUP_FRESH=0
+NUC_INFER_FRESH=1;   remote_session_exists "$NUC_SSH_HOST" fr3-inference && NUC_INFER_FRESH=0
+SHEEP_FRESH=1;       remote_session_exists "$SHEEP_SSH_HOST" polyumi     && SHEEP_FRESH=0
 if [ "$NUC_BRINGUP_FRESH$NUC_INFER_FRESH$SHEEP_FRESH" != "111" ]; then
   echo "Re-attaching to remote sessions that are already running; leaving those panes untouched."
 fi
@@ -156,81 +172,93 @@ remote_shell() {
   fi
 }
 
+# Every pane below is addressed by the pane ID tmux hands back from -P -F (%0, %7, ...), never
+# by a "window.index" string. Indices are not ours to predict: `pane-base-index 1` in the
+# operator's ~/.tmux.conf — a common setting — makes every ".0" target here miss, and the script
+# would then type robot commands into whatever pane it did find. IDs are assigned by tmux,
+# unique for the life of the server, and immune to both that option and to later splits.
+#
+# Window IDs (@0, @1, ...) are captured alongside the pane IDs where a window gets used as an
+# anchor: `new-window -t` and `select-window -t` take a target-WINDOW and reject a pane spec
+# outright ("can't specify pane here"), so a pane ID cannot stand in for one.
+#
 # ---------------------------------------------------------------------------
 # Window 1: the NUC — hardware session and inference stack, one pane each.
 # Split because bringup is the piece that crashes mid-session and needs restarting on its own
 # (docs/crb-fr3-inference.md, "TF lookup fails"), which is also why they are two launch files.
 # ---------------------------------------------------------------------------
-tmux new-session -d -s "$SESSION" -n nuc -c "$REPO_DIR"
-tmux send-keys -t "$SESSION:nuc.0" "$(remote_shell jailfranka fr3-bringup)" C-m
-tmux split-window -t "$SESSION:nuc" -h -c "$REPO_DIR"
-tmux send-keys -t "$SESSION:nuc.1" "$(remote_shell jailfranka fr3-inference)" C-m
+read -r NUC_BRINGUP_PANE NUC_WINDOW < <(
+  tmux new-session -d -P -F '#{pane_id} #{window_id}' -s "$SESSION" -n nuc -c "$REPO_DIR")
+tmux send-keys -t "$NUC_BRINGUP_PANE" "$(remote_shell "$NUC_SSH_HOST" fr3-bringup)" C-m
+NUC_INFER_PANE="$(tmux split-window -t "$NUC_BRINGUP_PANE" -h -P -F '#{pane_id}' -c "$REPO_DIR")"
+tmux send-keys -t "$NUC_INFER_PANE" "$(remote_shell "$NUC_SSH_HOST" fr3-inference)" C-m
 
 # ---------------------------------------------------------------------------
 # Window 2: the Pi (camera/audio stream) and the GPU box (policy server).
 # ---------------------------------------------------------------------------
-# `-a -t "$SESSION:nuc"` (a WINDOW target, by name), not `-t "$SESSION"` (a session target).
-# tmux resolves a bare session target to its CURRENT ACTIVE window and tries to create the new
-# window there — and by this point that's window 0 ("nuc", still active since nothing has
-# switched off it). Without -a that fails outright with "index 0 in use" the moment two windows
-# exist; -a instead means "insert right after this window, shifting later ones if needed",
-# which is what we actually want and cannot fail this way. Verified empirically: the plain
-# `-t "$SESSION"` form intermittently threw exactly that error once >= 2 windows existed.
-tmux new-window -a -t "$SESSION:nuc" -n polyumi-pi -c "$REPO_DIR"
-tmux send-keys -t "$SESSION:polyumi-pi.0" "ssh -t $PI_SSH_HOST" C-m
-tmux split-window -t "$SESSION:polyumi-pi" -h -c "$REPO_DIR"
-tmux send-keys -t "$SESSION:polyumi-pi.1" "$(remote_shell sheep polyumi)" C-m
+# `-a -t "$NUC_WINDOW"` (a WINDOW target), not `-t "$SESSION"` (a session target). tmux resolves
+# a bare session target to its CURRENT ACTIVE window and tries to create the new window there —
+# and by this point that's the "nuc" window, still active since nothing has switched off it.
+# Without -a that fails outright with "index N in use" the moment two windows exist; -a instead
+# means "insert right after this window, shifting later ones if needed", which is what we
+# actually want and cannot fail this way. Verified empirically: the plain `-t "$SESSION"` form
+# intermittently threw exactly that error once >= 2 windows existed.
+read -r PI_PANE PI_WINDOW < <(
+  tmux new-window -a -t "$NUC_WINDOW" -n polyumi-pi -P -F '#{pane_id} #{window_id}' -c "$REPO_DIR")
+tmux send-keys -t "$PI_PANE" "ssh -t $PI_SSH_HOST" C-m
+SHEEP_PANE="$(tmux split-window -t "$PI_PANE" -h -P -F '#{pane_id}' -c "$REPO_DIR")"
+tmux send-keys -t "$SHEEP_PANE" "$(remote_shell "$SHEEP_SSH_HOST" polyumi)" C-m
 
 # ---------------------------------------------------------------------------
 # Window 3: this laptop — DDS env sourced, ready to launch the client.
 # ---------------------------------------------------------------------------
-tmux new-window -a -t "$SESSION:polyumi-pi" -n laptop -c "$REPO_DIR"
-tmux send-keys -t "$SESSION:laptop.0" "source setup_franka_env.sh" C-m
+LAPTOP_PANE="$(tmux new-window -a -t "$PI_WINDOW" -n laptop -P -F '#{pane_id}' -c "$REPO_DIR")"
+tmux send-keys -t "$LAPTOP_PANE" "source setup_franka_env.sh" C-m
 
 # Everything above only opened shells. Let them finish before typing into them.
 sleep "$SHELL_SETTLE_S"
 
-# --- NUC pane 0: RUN bringup. Safe (no motion) and everything else waits on it. If FCI is not
-# --- enabled on the Desk UI it fails loudly and you re-run it; that is cheap.
+# --- NUC, left pane: RUN bringup. Safe (no motion) and everything else waits on it. If FCI is
+# --- not enabled on the Desk UI it fails loudly and you re-run it; that is cheap.
 if [ "$NUC_BRINGUP_FRESH" = 1 ]; then
-  tmux send-keys -t "$SESSION:nuc.0" "cd $NUC_REPO && ros2 launch nuc/launch/fr3_bringup.launch.py" C-m
+  tmux send-keys -t "$NUC_BRINGUP_PANE" "cd $NUC_REPO && ros2 launch nuc/launch/fr3_bringup.launch.py" C-m
 fi
 
-# --- NUC pane 1: PRETYPE. Carries the execute flags, so it is yours to press Enter on. 
+# --- NUC, right pane: PRETYPE. Carries the execute flags, so it is yours to press Enter on.
 if [ "$NUC_INFER_FRESH" = 1 ]; then
-  tmux send-keys -t "$SESSION:nuc.1" "cd $NUC_REPO" C-m
-  pretype "$SESSION:nuc.1" "ros2 launch nuc/launch/fr3_inference.launch.py execute_gripper:=true execute_arm:=true max_velocity_scaling:=0.2"
+  tmux send-keys -t "$NUC_INFER_PANE" "cd $NUC_REPO" C-m
+  pretype "$NUC_INFER_PANE" "ros2 launch nuc/launch/fr3_inference.launch.py execute_gripper:=true execute_arm:=true max_velocity_scaling:=0.2"
 fi
 
 # --- Pi: RUN the stream. Stateless, moves nothing, and the laptop warns without it.
-tmux send-keys -t "$SESSION:polyumi-pi.0" "polyumi-pi stream" C-m
+tmux send-keys -t "$PI_PANE" "polyumi-pi stream" C-m
 
 # --- Sheep: PRETYPE. The checkpoint changes every training run, so the path is yours to pick.
 # --- The five most recent are listed above the prompt to save a hunt through dp_outputs/.
 if [ "$SHEEP_FRESH" = 1 ]; then
-  tmux send-keys -t "$SESSION:polyumi-pi.1" "cd $SHEEP_REPO" C-m
-  tmux send-keys -t "$SESSION:polyumi-pi.1" \
+  tmux send-keys -t "$SHEEP_PANE" "cd $SHEEP_REPO" C-m
+  tmux send-keys -t "$SHEEP_PANE" \
     "ls -t data/dp_outputs/*/*/checkpoints/latest.ckpt 2>/dev/null | head -5" C-m
-  pretype "$SESSION:polyumi-pi.1" "CKPT=\$(ls -t $SHEEP_REPO/data/dp_outputs/*/*/checkpoints/latest.ckpt | head -1) ./serve_policy.sh"
+  pretype "$SHEEP_PANE" "CKPT=\$(ls -t $SHEEP_REPO/data/dp_outputs/*/*/checkpoints/latest.ckpt | head -1) ./serve_policy.sh"
 fi
 
 # --- Laptop: PRETYPE. Depends on every pane above being live, and there is no readiness gate
 # --- here, so this is the one you press Enter on last.
-pretype "$SESSION:laptop.0" "ros2 launch polyumi_ros2 inference_demo.launch.xml inference_server_url:=$INFERENCE_URL execute_motion:=true max_image_age_s:=$MAX_IMAGE_AGE_S pi_host:=$PI_HOST"
+pretype "$LAPTOP_PANE" "ros2 launch polyumi_ros2 inference_demo.launch.xml inference_server_url:=$INFERENCE_URL execute_motion:=true max_image_age_s:=$MAX_IMAGE_AGE_S pi_host:=$PI_HOST"
 
-tmux select-window -t "$SESSION:nuc"
+tmux select-window -t "$NUC_WINDOW"
 cat <<EOF
 
 Session '$SESSION' is up. Order to press Enter in:
-  1. nuc.0     already running bringup (enable FCI on the Desk UI first if it errors)
-  2. nuc.1     the inference stack — check the execute flags on the line before you run it
-  3. polyumi-pi.1    the policy server — edit CKPT to the checkpoint you want
-  4. laptop.0  the client, last
+  1. nuc, left      already running bringup (enable FCI on the Desk UI first if it errors)
+  2. nuc, right     the inference stack — check the execute flags on the line before you run it
+  3. polyumi-pi, right   the policy server — edit CKPT to the checkpoint you want
+  4. laptop         the client, last
 
 tmux, minimum viable:
   C-b n / C-b p    next / previous window        C-b o     next pane
   C-b d            detach (everything keeps running)
-  C-b C-b          send a prefix to the INNER tmux on jailfranka/sheep
+  C-b C-b          send a prefix to the INNER tmux on $NUC_SSH_HOST/$SHEEP_SSH_HOST
 Re-attach any time with ./fr3_session.sh — remote panes pick up where they left off.
 
 EOF

--- a/fr3_session.sh
+++ b/fr3_session.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# Bring up the whole FR3 inference wall — NUC, Pi, GPU box, laptop — as one tmux session.
+#
+# Replaces the seven-terminal ssh-and-remember dance in docs/crb-fr3-inference.md with:
+#
+#     ./fr3_session.sh                # create (or re-attach to) the session
+#     SKIP_DEPLOY=1 ./fr3_session.sh  # ...without re-syncing the NUC/Pi source trees first
+#     ./fr3_session.sh --kill-local   # tear down the LOCAL session only (remote ones survive)
+#     ./fr3_session.sh --kill         # --kill-local, plus stop the remote sessions too
+#
+# Every fresh start (not a re-attach) also pushes this working copy to the machines that run
+# it — rsyncs nuc/ to the NUC, and calls ./deploy.sh for the Pi — so what runs remotely always
+# matches what you have checked out here. See the "Deploy" section below.
+#
+# WHERE TMUX RUNS, AND WHY IT MATTERS
+# The NUC and GPU-box panes run tmux *on the remote host* (`ssh -t host tmux new -A -s ...`),
+# not a bare ssh. Two reasons:
+#   1. A laptop sleep or wifi blip then costs you nothing — the arm session and the policy
+#      server keep running, and re-running this script re-attaches to them.
+#   2. It fixes the env trap in docs/crb-fr3-inference.md: a non-interactive shell does not
+#      source ~/.bashrc, so `ssh host 'cmd'` comes up without CYCLONEDDS_URI, on the wrong
+#      RMW, invisible to everything else. `ssh -t host tmux` gets an interactive shell, so the
+#      DDS env and the fr3-* aliases are simply there.
+# The Pi is a plain ssh: it is stateless and cheap to restart, so the extra layer buys nothing.
+#
+# WHAT AUTO-RUNS, AND WHAT ONLY GETS TYPED
+# Commands that are safe and order-independent are run for you. Commands that need a decision
+# (which checkpoint, whether the arm is allowed to move) are *typed into the prompt but not
+# executed* — review the line, edit it, press Enter. Nothing in here can move the robot on its
+# own. See PRETYPE vs RUN at each pane below.
+
+set -euo pipefail
+
+SESSION="${SESSION:-polyumi}"
+# Seconds to let a remote shell finish starting before typing into it. Pre-typing races the
+# ssh+tmux+shell startup; if lines land mangled or in the wrong pane, raise this.
+SHELL_SETTLE_S="${SHELL_SETTLE_S:-5}"
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Where the repo lives on each remote (verified on both hosts). Left unexpanded so the REMOTE
+# shell resolves the tilde against its own $HOME — franka on the NUC, xhy7159 on the GPU box.
+# Override from the environment if these ever move.
+NUC_REPO="${NUC_REPO:-~/Documents/PolyUMI}"
+SHEEP_REPO="${SHEEP_REPO:-~/repos/PolyUMI}"
+
+# ssh alias for the Pi. "polyumi-pi" is the name other users are expected to set up in their
+# own ssh config; override if yours is named differently (mine is "conorpi"):
+#   PI_SSH_HOST=conorpi ./fr3_session.sh
+PI_SSH_HOST="${PI_SSH_HOST:-polyumi-pi}"
+
+INFERENCE_URL="${INFERENCE_URL:-http://sheep.mech.northwestern.edu:8000/predict_cartesian/}"
+# The Elgato's 1080p software convert runs ~200ms behind; the 50ms auto default drops every tick.
+MAX_IMAGE_AGE_S="${MAX_IMAGE_AGE_S:-0.3}"
+
+if [ "${1:-}" = "--kill-local" ] || [ "${1:-}" = "--kill" ]; then
+  tmux kill-session -t "$SESSION" 2>/dev/null && echo "Killed local session '$SESSION'."
+  if [ "${1:-}" = "--kill-local" ]; then
+    echo "NOTE: the remote tmux sessions on jailfranka/sheep are still running by design."
+    echo "      To stop those too:  ./fr3_session.sh --kill"
+    exit 0
+  fi
+
+  # --kill: also stop the specific remote sessions this script owns. kill-session, not
+  # kill-server — the remote might be running other tmux sessions unrelated to us.
+  kill_remote_session() {
+    local host="$1" sess="$2"
+    if ssh -o ConnectTimeout=5 -o BatchMode=yes "$host" "tmux kill-session -t $sess" 2>/dev/null; then
+      echo "Killed remote session '$sess' on $host."
+    else
+      echo "No remote session '$sess' on $host (already gone, or host unreachable)."
+    fi
+  }
+  kill_remote_session jailfranka fr3-bringup
+  kill_remote_session jailfranka fr3-inference
+  kill_remote_session sheep polyumi
+  exit 0
+fi
+
+# Already up? Just re-attach — this is the normal path after a laptop sleep.
+if tmux has-session -t "$SESSION" 2>/dev/null; then
+  echo "Session '$SESSION' exists; attaching."
+  exec tmux attach -t "$SESSION"
+fi
+
+# The Pi is on DHCP and its address really does change between sessions, so resolve it from the
+# ssh config rather than baking in a literal that is wrong by next week. One source of truth.
+PI_HOST="$(ssh -G "$PI_SSH_HOST" 2>/dev/null | awk '/^hostname /{print $2}')"
+if [ -z "$PI_HOST" ]; then
+  echo "ERROR: could not resolve '$PI_SSH_HOST' from your ssh config." >&2
+  echo "       Set PI_SSH_HOST to your Pi's ssh alias, e.g.: PI_SSH_HOST=conorpi ./fr3_session.sh" >&2
+  exit 1
+fi
+echo "Pi resolved to $PI_HOST (ssh alias: $PI_SSH_HOST)"
+
+# ---------------------------------------------------------------------------
+# Deploy: bring the NUC and Pi source trees in line with this working copy before anything
+# runs against them — the fix for "I edited a launch file locally and the NUC ran the old one".
+# SKIP_DEPLOY=1 bypasses both for a fast re-launch once you know they're already current.
+# Non-fatal per target: a machine that's unreachable (Pi powered off, say) warns and is
+# skipped rather than blocking the machines that ARE up. Sheep is deliberately not included —
+# it tracks its own training branch, not this one, so force-syncing it would be wrong.
+# ---------------------------------------------------------------------------
+if [ "${SKIP_DEPLOY:-0}" = 1 ]; then
+  echo "SKIP_DEPLOY=1 — leaving the NUC and Pi source trees as they are."
+else
+  echo "==> Syncing nuc/ to jailfranka:$NUC_REPO ..."
+  if rsync -a --delete --mkpath --exclude='__pycache__/' --exclude='*.pyc' \
+      nuc "jailfranka:${NUC_REPO}/"; then
+    echo "    done."
+  else
+    echo "WARNING: rsync to jailfranka failed — it may be running stale nuc/ code." >&2
+  fi
+
+  echo "==> Deploying pi/ to $PI_SSH_HOST via ./deploy.sh ..."
+  if ! (cd "$REPO_DIR" && ./deploy.sh "$PI_SSH_HOST"); then
+    echo "WARNING: deploy.sh failed (Pi unreachable?) — it may be running stale code." >&2
+  fi
+fi
+
+# Is a remote session already running? Probed BEFORE any pane is opened, because attaching
+# creates it. This is the re-attach case: the laptop went away but the NUC kept working.
+remote_session_exists() {
+  ssh -o ConnectTimeout=5 -o BatchMode=yes "$1" "tmux has-session -t $2" 2>/dev/null
+}
+
+# A live remote session must NOT be typed into. Its shell may be mid-run (bringup), or holding
+# a pre-typed line the operator has not pressed Enter on yet — and send-keys appends to that
+# readline buffer rather than replacing it, so a second pass concatenates two commands and
+# submits the result. Re-attaching is supposed to hand the pane back exactly as it was.
+NUC_BRINGUP_FRESH=1; remote_session_exists jailfranka fr3-bringup   && NUC_BRINGUP_FRESH=0
+NUC_INFER_FRESH=1;   remote_session_exists jailfranka fr3-inference && NUC_INFER_FRESH=0
+SHEEP_FRESH=1;       remote_session_exists sheep polyumi            && SHEEP_FRESH=0
+if [ "$NUC_BRINGUP_FRESH$NUC_INFER_FRESH$SHEEP_FRESH" != "111" ]; then
+  echo "Re-attaching to remote sessions that are already running; leaving those panes untouched."
+fi
+
+# Type a command into a pane and leave the cursor on it, unexecuted. The point is that the
+# operator reads and confirms the line — this is how every robot-moving command gets in.
+pretype() { tmux send-keys -t "$1" "$2"; }
+
+# Build the command that opens a durable shell on a remote host.
+#
+# Prefers a tmux ON THE REMOTE, so the pane survives a laptop sleep or a dropped link — but
+# degrades to a plain ssh when the host has no tmux or is not answering, rather than handing
+# back a pane that opens and then silently does nothing. Degrading beats failing here: one
+# machine being down should not block bringing the others up.
+remote_shell() {
+  local host="$1" session="$2"
+  if ssh -o ConnectTimeout=5 -o BatchMode=yes "$host" 'command -v tmux >/dev/null' 2>/dev/null; then
+    echo "ssh -t $host 'tmux new-session -A -s $session'"
+  else
+    echo "WARNING: $host has no remote tmux (not installed, or host unreachable)." >&2
+    echo "         Using a plain ssh — this pane will NOT survive a disconnect." >&2
+    echo "         Fix with:  ssh $host 'sudo apt install tmux'" >&2
+    echo "ssh -t $host"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Window 1: the NUC — hardware session and inference stack, one pane each.
+# Split because bringup is the piece that crashes mid-session and needs restarting on its own
+# (docs/crb-fr3-inference.md, "TF lookup fails"), which is also why they are two launch files.
+# ---------------------------------------------------------------------------
+tmux new-session -d -s "$SESSION" -n nuc -c "$REPO_DIR"
+tmux send-keys -t "$SESSION:nuc.0" "$(remote_shell jailfranka fr3-bringup)" C-m
+tmux split-window -t "$SESSION:nuc" -h -c "$REPO_DIR"
+tmux send-keys -t "$SESSION:nuc.1" "$(remote_shell jailfranka fr3-inference)" C-m
+
+# ---------------------------------------------------------------------------
+# Window 2: the Pi (camera/audio stream) and the GPU box (policy server).
+# ---------------------------------------------------------------------------
+# `-a -t "$SESSION:nuc"` (a WINDOW target, by name), not `-t "$SESSION"` (a session target).
+# tmux resolves a bare session target to its CURRENT ACTIVE window and tries to create the new
+# window there — and by this point that's window 0 ("nuc", still active since nothing has
+# switched off it). Without -a that fails outright with "index 0 in use" the moment two windows
+# exist; -a instead means "insert right after this window, shifting later ones if needed",
+# which is what we actually want and cannot fail this way. Verified empirically: the plain
+# `-t "$SESSION"` form intermittently threw exactly that error once >= 2 windows existed.
+tmux new-window -a -t "$SESSION:nuc" -n polyumi-pi -c "$REPO_DIR"
+tmux send-keys -t "$SESSION:polyumi-pi.0" "ssh -t $PI_SSH_HOST" C-m
+tmux split-window -t "$SESSION:polyumi-pi" -h -c "$REPO_DIR"
+tmux send-keys -t "$SESSION:polyumi-pi.1" "$(remote_shell sheep polyumi)" C-m
+
+# ---------------------------------------------------------------------------
+# Window 3: this laptop — DDS env sourced, ready to launch the client.
+# ---------------------------------------------------------------------------
+tmux new-window -a -t "$SESSION:polyumi-pi" -n laptop -c "$REPO_DIR"
+tmux send-keys -t "$SESSION:laptop.0" "source setup_franka_env.sh" C-m
+
+# Everything above only opened shells. Let them finish before typing into them.
+sleep "$SHELL_SETTLE_S"
+
+# --- NUC pane 0: RUN bringup. Safe (no motion) and everything else waits on it. If FCI is not
+# --- enabled on the Desk UI it fails loudly and you re-run it; that is cheap.
+if [ "$NUC_BRINGUP_FRESH" = 1 ]; then
+  tmux send-keys -t "$SESSION:nuc.0" "cd $NUC_REPO && ros2 launch nuc/launch/fr3_bringup.launch.py" C-m
+fi
+
+# --- NUC pane 1: PRETYPE. Carries the execute flags, so it is yours to press Enter on. 
+if [ "$NUC_INFER_FRESH" = 1 ]; then
+  tmux send-keys -t "$SESSION:nuc.1" "cd $NUC_REPO" C-m
+  pretype "$SESSION:nuc.1" "ros2 launch nuc/launch/fr3_inference.launch.py execute_gripper:=true execute_arm:=true max_velocity_scaling:=0.2"
+fi
+
+# --- Pi: RUN the stream. Stateless, moves nothing, and the laptop warns without it.
+tmux send-keys -t "$SESSION:polyumi-pi.0" "polyumi-pi stream" C-m
+
+# --- Sheep: PRETYPE. The checkpoint changes every training run, so the path is yours to pick.
+# --- The five most recent are listed above the prompt to save a hunt through dp_outputs/.
+if [ "$SHEEP_FRESH" = 1 ]; then
+  tmux send-keys -t "$SESSION:polyumi-pi.1" "cd $SHEEP_REPO" C-m
+  tmux send-keys -t "$SESSION:polyumi-pi.1" \
+    "ls -t data/dp_outputs/*/*/checkpoints/latest.ckpt 2>/dev/null | head -5" C-m
+  pretype "$SESSION:polyumi-pi.1" "CKPT=\$(ls -t $SHEEP_REPO/data/dp_outputs/*/*/checkpoints/latest.ckpt | head -1) ./serve_policy.sh"
+fi
+
+# --- Laptop: PRETYPE. Depends on every pane above being live, and there is no readiness gate
+# --- here, so this is the one you press Enter on last.
+pretype "$SESSION:laptop.0" "ros2 launch polyumi_ros2 inference_demo.launch.xml inference_server_url:=$INFERENCE_URL execute_motion:=true max_image_age_s:=$MAX_IMAGE_AGE_S pi_host:=$PI_HOST"
+
+tmux select-window -t "$SESSION:nuc"
+cat <<EOF
+
+Session '$SESSION' is up. Order to press Enter in:
+  1. nuc.0     already running bringup (enable FCI on the Desk UI first if it errors)
+  2. nuc.1     the inference stack — check the execute flags on the line before you run it
+  3. polyumi-pi.1    the policy server — edit CKPT to the checkpoint you want
+  4. laptop.0  the client, last
+
+tmux, minimum viable:
+  C-b n / C-b p    next / previous window        C-b o     next pane
+  C-b d            detach (everything keeps running)
+  C-b C-b          send a prefix to the INNER tmux on jailfranka/sheep
+Re-attach any time with ./fr3_session.sh — remote panes pick up where they left off.
+
+EOF
+exec tmux attach -t "$SESSION"

--- a/inference_server/inference_server/dummy_server.py
+++ b/inference_server/inference_server/dummy_server.py
@@ -5,6 +5,11 @@ Implements the /predict_cartesian/ endpoint with a sine-wave oscillator instead 
 policy, so the ROS2 policy_client_node can be developed and tested end-to-end without a
 trained checkpoint.
 
+Two channels oscillate, at the same frequency but 90 degrees apart: X on a sine, gripper width
+on a cosine. The phase offset is deliberate — the gripper's extremes land on X's zero crossings,
+so a routing bug that feeds X into the gripper (or vice versa) is visible at a glance in the logs
+and in Foxglove, instead of looking perfectly plausible.
+
 Usage:
     HOME_POSE="0.4 0.0 0.4 0 0 0 1 0.04" uv run uvicorn inference_server.dummy_server:app --host 0.0.0.0 --port 8000
 """
@@ -27,7 +32,15 @@ REQUIRED_OBS_KEYS = {'image', 'agent_pos'}
 AGENT_POS_DIM = 8  # [x, y, z, qx, qy, qz, qw, gripper_width]
 OSCILLATION_AMPLITUDE_M = 0.05
 OSCILLATION_PERIOD_STEPS = 20  # full cycle over this many /predict calls
-DEFAULT_HOME_POSE = '0.56 0.13 0.25 -1 0 0 0 0.4'  # xyz qxqyqzqw gripper
+# Gripper swing, in the same units as the training data (ArUco finger-tag separation, NOT the
+# robot's jaw aperture — policy_client_node applies the offset, see docs/franka-inference-bringup.md
+# "Phase 2.5"). Centred on the home width, so keep amplitude <= that to stay non-negative.
+GRIPPER_OSCILLATION_AMPLITUDE_M = 0.04
+DEFAULT_HOME_POSE = '0.56 0.13 0.25 -1 0 0 0 0.05'  # xyz qxqyqzqw gripper
+# Sanity bound on the home gripper width. The Franka Hand tops out near 0.0817 m and the handheld
+# gripper's tags separate to ~0.1 m, so anything past this is a units error (this default used to
+# read 0.4 — 400 mm — which went unnoticed only because the width was being dropped downstream).
+MAX_PLAUSIBLE_GRIPPER_M = 0.2
 
 
 class PredictRequest(BaseModel):
@@ -60,6 +73,13 @@ async def _lifespan(app: FastAPI):
     vals = [float(v) for v in raw.split()]
     if len(vals) != AGENT_POS_DIM:
         raise ValueError(f'HOME_POSE must have {AGENT_POS_DIM} values (xyz qxqyqzqw gripper), got {len(vals)}')
+    gripper = vals[-1]
+    if not 0.0 < gripper <= MAX_PLAUSIBLE_GRIPPER_M:
+        raise ValueError(
+            f'HOME_POSE gripper width {gripper} m is out of range (0, {MAX_PLAUSIBLE_GRIPPER_M}]. '
+            'The last HOME_POSE value is a width in METRES — a value like 0.4 is 400 mm, ~5x the '
+            'Franka Hand\'s stroke. Did you mean 0.04?'
+        )
     _home_pose = np.array(vals)
     yield
 
@@ -121,8 +141,8 @@ def predict_cartesian(req: PredictRequest) -> PredictResponse:
             detail=f'agent_pos must have shape [{req.n_obs_steps}, {AGENT_POS_DIM}]',
         )
 
-    # Oscillate X around the fixed home pose (set via HOME_POSE env var at startup).
-    # Return a genuine forward-looking chunk — one pose per step, phase advancing by one
+    # Oscillate X and the gripper width around the fixed home pose (set via HOME_POSE env var at
+    # startup). Return a genuine forward-looking chunk — one pose per step, phase advancing by one
     # OSCILLATION_PERIOD_STEPS-th per step — rather than n_return copies of a single pose,
     # so the client has an actual multi-waypoint path to plan+execute (not n identical
     # points). _call_count advances by the full chunk length so consecutive calls continue
@@ -134,8 +154,13 @@ def predict_cartesian(req: PredictRequest) -> PredictResponse:
     for i in range(n_return):
         phase = 2 * math.pi * (_call_count + i) / OSCILLATION_PERIOD_STEPS
         delta_x = OSCILLATION_AMPLITUDE_M * math.sin(phase)
+        # cos against X's sin — same frequency, quarter period apart. See the module docstring:
+        # this is what makes a gripper/pose routing mix-up visible rather than plausible.
+        delta_grip = GRIPPER_OSCILLATION_AMPLITUDE_M * math.cos(phase)
         target = _home_pose.copy()
         target[0] += delta_x
+        # Clamp at 0: a negative width is meaningless, and the client would clamp it anyway.
+        target[7] = max(0.0, target[7] + delta_grip)
         actions.append(target.tolist())
     _call_count += n_return
 

--- a/inference_server/pyproject.toml
+++ b/inference_server/pyproject.toml
@@ -15,3 +15,10 @@ dependencies = [
 
 [project.scripts]
 dummy-server = "inference_server.dummy_server:main"
+
+[dependency-groups]
+# httpx is what fastapi's TestClient drives the app through.
+dev = [
+    "pytest>=8.0",
+    "httpx>=0.27",
+]

--- a/inference_server/test/test_dummy_server.py
+++ b/inference_server/test/test_dummy_server.py
@@ -1,0 +1,128 @@
+"""
+Tests for the dummy inference server's oscillator and HOME_POSE validation.
+
+The dummy is the only thing exercising the ROS-side action path without a GPU or a checkpoint,
+so its output shape matters: if the gripper channel is constant, a broken gripper route looks
+identical to a working one.
+"""
+
+import base64
+import os
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+from fastapi.testclient import TestClient
+
+from inference_server.dummy_server import (
+    GRIPPER_OSCILLATION_AMPLITUDE_M,
+    OSCILLATION_AMPLITUDE_M,
+    OSCILLATION_PERIOD_STEPS,
+    app,
+)
+
+HOME_GRIPPER = 0.05
+HOME_POSE = f'0.56 0.13 0.25 -1 0 0 0 {HOME_GRIPPER}'
+
+
+def _request_body(n_action_steps: int = 8, n_obs_steps: int = 2) -> dict:
+    """Build a structurally valid /predict_cartesian/ body."""
+    image = np.full((n_obs_steps, 8, 8, 3), 0.5, dtype=np.float32)
+    return {
+        'n_obs_steps': n_obs_steps,
+        'n_action_steps': n_action_steps,
+        'observations': {
+            'image': {
+                'dtype': 'float32',
+                'shape': list(image.shape),
+                'data': base64.b64encode(image.tobytes()).decode(),
+            },
+            'agent_pos': [[0.4, 0.0, 0.4, 0.0, 0.0, 0.0, 1.0, 0.04]] * n_obs_steps,
+        },
+    }
+
+
+@pytest.fixture
+def client():
+    """Build a TestClient with a known HOME_POSE, so the oscillation centre is predictable."""
+    with patch.dict(os.environ, {'HOME_POSE': HOME_POSE}), TestClient(app) as test_client:
+        yield test_client
+
+
+def test_gripper_oscillates(client):
+    """
+    The gripper channel actually varies — the point of the whole exercise.
+
+    A constant here would make a dropped or mis-routed gripper command indistinguishable from a
+    working one during bringup.
+    """
+    widths = []
+    for _ in range(4):
+        actions = client.post('/predict_cartesian/', json=_request_body()).json()['actions']
+        widths.extend(a[7] for a in actions)
+
+    assert len(set(widths)) > 1
+    assert min(widths) < HOME_GRIPPER < max(widths)
+
+
+def test_gripper_stays_in_a_plausible_range(client):
+    """Widths stay non-negative and within the amplitude of the home width."""
+    widths = []
+    for _ in range(4):
+        actions = client.post('/predict_cartesian/', json=_request_body()).json()['actions']
+        widths.extend(a[7] for a in actions)
+
+    assert min(widths) >= 0.0
+    assert max(widths) <= HOME_GRIPPER + GRIPPER_OSCILLATION_AMPLITUDE_M + 1e-9
+
+
+def test_gripper_is_a_quarter_period_out_of_phase_with_x(client):
+    """
+    X and the gripper share a frequency but not a phase — deliberately.
+
+    X is a sine and the gripper a cosine about their home values, so where X crosses its centre
+    the gripper is at an extreme. That is what makes a routing bug (X wired into the gripper)
+    visible on inspection instead of merely plausible. Checking sin^2 + cos^2 == 1 pins the
+    relationship without depending on which sample lands where.
+    """
+    # One full period, so the assertion covers every phase rather than a lucky few.
+    actions = client.post(
+        '/predict_cartesian/', json=_request_body(n_action_steps=OSCILLATION_PERIOD_STEPS)
+    ).json()['actions']
+
+    for action in actions:
+        sin_component = (action[0] - 0.56) / OSCILLATION_AMPLITUDE_M
+        cos_component = (action[7] - HOME_GRIPPER) / GRIPPER_OSCILLATION_AMPLITUDE_M
+        assert sin_component**2 + cos_component**2 == pytest.approx(1.0, abs=1e-6)
+
+
+def test_phase_advances_across_calls(client):
+    """Consecutive calls continue the waveform rather than restarting from the same phase."""
+    first = client.post('/predict_cartesian/', json=_request_body()).json()['actions']
+    second = client.post('/predict_cartesian/', json=_request_body()).json()['actions']
+
+    assert first[0][7] != pytest.approx(second[0][7])
+
+
+@pytest.mark.parametrize('bad_gripper', ['0.4', '0', '-0.02', '5'])
+def test_home_pose_rejects_implausible_gripper_width(bad_gripper):
+    """
+    An out-of-range home width fails at startup instead of being commanded at the hand.
+
+    The shipped default really was 0.4 (400 mm, ~5x the Franka Hand's stroke) and went unnoticed
+    only because the width was being dropped downstream. Once it is routed, that is a goal the
+    gripper aborts on every tick.
+    """
+    home = f'0.56 0.13 0.25 -1 0 0 0 {bad_gripper}'
+    with patch.dict(os.environ, {'HOME_POSE': home}):
+        with pytest.raises(ValueError, match='gripper width'):
+            with TestClient(app):
+                pass
+
+
+def test_home_pose_rejects_wrong_length():
+    """A HOME_POSE with the wrong number of values is rejected with a clear message."""
+    with patch.dict(os.environ, {'HOME_POSE': '0.5 0.1 0.2'}):
+        with pytest.raises(ValueError, match='must have 8 values'):
+            with TestClient(app):
+                pass

--- a/inference_server/uv.lock
+++ b/inference_server/uv.lock
@@ -34,6 +34,15 @@ wheels = [
 ]
 
 [[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -80,6 +89,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
 name = "httptools"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -116,6 +138,21 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.18"
 source = { registry = "https://pypi.org/simple" }
@@ -134,11 +171,32 @@ dependencies = [
     { name = "uvicorn", extra = ["standard"] },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "httpx" },
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "fastapi", specifier = ">=0.115" },
     { name = "numpy", specifier = ">=2.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "pytest", specifier = ">=8.0" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -200,6 +258,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9c/50/0753655aa844c99cd9e018aacf76f130f1bd81d881bb74bc0aef5d73a8ba/numpy-2.4.6-cp314-cp314t-win32.whl", hash = "sha256:260a5d70215b61ab4fadf5c7baacd64821842975eea312125ed3c39a6391b063", size = 6156982, upload-time = "2026-05-18T23:36:40.817Z" },
     { url = "https://files.pythonhosted.org/packages/b2/d4/7c67becf668f973cb490cec3e98dfd799d866f9c989a54d355672cfa0db6/numpy-2.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:81a1cca95ed5bb92aa8b10dd2cdc9a0d3853a50fad926c28b5d7e8ea54389627", size = 12638908, upload-time = "2026-05-18T23:36:43.996Z" },
     { url = "https://files.pythonhosted.org/packages/43/bb/e1c71a4295b1b1d1393d50dbb4f2a36283c6859d9d3892e84f00ec5a91d5/numpy-2.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:0c9136e14ed34a9e343a31c533d78a9813a69a3148332bce5e9821cb2f996e66", size = 10565867, upload-time = "2026-05-18T23:36:47.114Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -290,6 +366,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
     { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
     { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]

--- a/nuc/fr3_gripper_bridge.py
+++ b/nuc/fr3_gripper_bridge.py
@@ -319,8 +319,20 @@ class Fr3GripperBridge(Node):
         future.add_done_callback(lambda f: self._on_goal_response(f, label, width))
 
     def _on_goal_response(self, future, label: str, width: float) -> None:
-        """Handle goal acceptance, record what was commanded, then chain to the result."""
-        handle = future.result()
+        """
+        Handle goal acceptance, record what was commanded, then chain to the result.
+
+        rclpy's ``Future.result()`` **re-raises** whatever exception the send stored rather than
+        returning None, and this runs as a done-callback — so an unguarded raise here escapes into
+        rclpy internals and skips _clear_in_flight, wedging the slot until the watchdog expires.
+        Catching it turns a silent GOAL_RESULT_TIMEOUT_S stall into an immediate retry.
+        """
+        try:
+            handle = future.result()
+        except Exception as e:  # broad on purpose: ANY send failure must still free the slot
+            self.get_logger().warning(f'{label} goal failed to send: {e} (will retry).')
+            self._clear_in_flight()
+            return
         if handle is None or not handle.accepted:
             # Leave _last_commanded alone: the hand never got this width, so the next tick should
             # be free to try again rather than treating it as already satisfied.
@@ -340,8 +352,16 @@ class Fr3GripperBridge(Node):
         moving target legitimately produces these. Treating them as faults would generate
         exactly the log spam the rate limiting exists to prevent. A *steady stream* of them
         still means the deadband or period is too small — see docs/crb-fr3-inference.md.
+
+        Guarded for the same reason as _on_goal_response: ``Future.result()`` re-raises, and an
+        escaping exception here would skip _clear_in_flight and wedge the slot.
         """
-        result = future.result()
+        try:
+            result = future.result()
+        except Exception as e:  # broad on purpose: ANY result failure must still free the slot
+            self.get_logger().warning(f'{label} result raised: {e}')
+            self._clear_in_flight()
+            return
         if result is None:
             self.get_logger().warning(f'{label} returned no result.')
         elif not result.result.success:

--- a/nuc/fr3_gripper_bridge.py
+++ b/nuc/fr3_gripper_bridge.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""
+FR3 gripper bridge — runs ON THE NUC (ROS 2 Humble).
+
+Subscribes to the gripper half of the inference action chunk on /polyumi/target_gripper (a
+trajectory_msgs/JointTrajectory published by the laptop's policy_client_node over DDS, one point
+per action step, positions in metres of JAW APERTURE) and drives the Franka Hand via its local
+action servers. Runs on the NUC for the same reason as fr3_moveit_bridge: same-rmw as the hardware.
+
+WHY THIS IS NOT A SERVO. UMI drives its gripper with a 30 Hz interpolated position+velocity
+stream (umi/real_world/wsg_controller.py, the same PoseTrajectoryInterpolator its arm uses). The
+Franka Hand cannot do that at any level of the stack: it has NO ros2_control interface at all
+(`ros2 control list_hardware_interfaces` lists nothing for the fingers), and libfranka's
+franka::Gripper exposes only blocking homing/grasp/move/stop. So instead of tracking every
+waypoint, this node holds the latest desired width and issues a discrete goal only when the
+target has moved past a deadband and a minimum period has elapsed.
+
+That rate limit is mandatory, not a nicety: franka_gripper's action server ACCEPTs every goal
+unconditionally into a detached thread, with no queue and no preemption, and libfranka aborts
+whichever command a new goal supersedes. Commanding at the 10 Hz control rate would produce ~9
+aborted goals per second plus unbounded thread churn.
+
+Self-contained (no PolyUMI package deps) so it runs from a plain clone on the NUC:
+    source /opt/ros/humble/setup.bash
+    source ~/franka_ws/install/setup.bash   # franka_gripper must be up (fr3-bringup)
+    export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+    export CYCLONEDDS_URI=file://$HOME/franka_ws/config/cyclonedds.xml
+    python3 nuc/fr3_gripper_bridge.py --ros-args -p execute:=false   # dry-run (no motion)
+
+Set execute:=true to actually move the fingers. Default is false (log only) for safety.
+"""
+
+import threading
+import time
+
+from franka_msgs.action import Grasp, Move
+import rclpy
+from rclpy.action import ActionClient
+from rclpy.callback_groups import ReentrantCallbackGroup
+from rclpy.executors import MultiThreadedExecutor
+from rclpy.node import Node
+from sensor_msgs.msg import JointState
+from trajectory_msgs.msg import JointTrajectory
+
+DEFAULT_TARGET_TOPIC = '/polyumi/target_gripper'
+DEFAULT_STATE_TOPIC = '/fr3_gripper/joint_states'
+
+# The hand's true max is ~0.0817 m after homing, but max_width is not published on any topic —
+# it lives only inside franka_gripper — so it has to be a constant here.
+DEFAULT_MAX_WIDTH = 0.08
+# Watchdog on the single in-flight goal slot. Goal resolution is callback-driven, so a goal that
+# never resolves (server died mid-motion, result callback lost) would otherwise wedge the bridge
+# permanently — it would stop commanding and never say why. A full-stroke Move at our slowest
+# allowed speed takes a few seconds, so this is generous.
+GOAL_RESULT_TIMEOUT_S = 10.0
+
+
+class Fr3GripperBridge(Node):
+    """Drive the Franka Hand from inference gripper-width chunks, deadbanded and rate-limited."""
+
+    def __init__(self):
+        """Declare params, create the target subscription and gripper action clients."""
+        super().__init__('fr3_gripper_bridge')
+
+        self.declare_parameter('execute', False)
+        self.declare_parameter('target_topic', DEFAULT_TARGET_TOPIC)
+        self.declare_parameter('state_topic', DEFAULT_STATE_TOPIC)
+        # Which point of the chunk to track. A chunk spans ~0.8 s while the hand needs 100s of ms
+        # to traverse, so 0 (track the first action) inherently lags; a small lead anticipates the
+        # policy's intent at the cost of closing early. Tune on hardware.
+        self.declare_parameter('gripper_lead_steps', 0)
+        # Ignore commanded widths within this of the last one we actually sent. This is what keeps
+        # a jittering policy output from turning into a goal storm.
+        self.declare_parameter('width_deadband_m', 0.005)
+        # Never issue goals faster than this, regardless of deadband.
+        self.declare_parameter('min_command_period_s', 0.25)
+        self.declare_parameter('max_width_m', DEFAULT_MAX_WIDTH)
+        # Move speed is derived from the chunk's own timing (see _desired_speed); these bound it.
+        self.declare_parameter('min_speed_mps', 0.02)
+        self.declare_parameter('max_speed_mps', 0.15)
+        # Grasp (force-controlled) instead of Move when closing below this width. 0.0 disables it,
+        # which is the shipped default: Move applies no force, so bringup moves fingers and nothing
+        # more. Raise it once you actually want to hold objects.
+        self.declare_parameter('use_grasp_below_m', 0.0)
+        self.declare_parameter('grasp_force_n', 20.0)
+        # Deliberately wide (the franka_gripper default is 0.005): with a continuously-commanded
+        # width, a tight band reports failure whenever the object isn't exactly the commanded size.
+        # Wide epsilon means "close until you hit something, then squeeze".
+        self.declare_parameter('grasp_epsilon_m', 0.05)
+
+        self._execute = self.get_parameter('execute').get_parameter_value().bool_value
+        topic = self.get_parameter('target_topic').get_parameter_value().string_value
+        state_topic = self.get_parameter('state_topic').get_parameter_value().string_value
+        self._lead_steps = self.get_parameter('gripper_lead_steps').get_parameter_value().integer_value
+        self._deadband = self.get_parameter('width_deadband_m').get_parameter_value().double_value
+        self._period = self.get_parameter('min_command_period_s').get_parameter_value().double_value
+        self._max_width = self.get_parameter('max_width_m').get_parameter_value().double_value
+        self._min_speed = self.get_parameter('min_speed_mps').get_parameter_value().double_value
+        self._max_speed = self.get_parameter('max_speed_mps').get_parameter_value().double_value
+        self._grasp_below = self.get_parameter('use_grasp_below_m').get_parameter_value().double_value
+        self._grasp_force = self.get_parameter('grasp_force_n').get_parameter_value().double_value
+        self._grasp_eps = self.get_parameter('grasp_epsilon_m').get_parameter_value().double_value
+
+        self._cbgroup = ReentrantCallbackGroup()
+        self._move = ActionClient(self, Move, '/fr3_gripper/move', callback_group=self._cbgroup)
+        self._grasp = ActionClient(self, Grasp, '/fr3_gripper/grasp', callback_group=self._cbgroup)
+
+        # Latest-wins target; no queue. _last_commanded is what we actually sent (not what was
+        # last requested), so the deadband measures drift from the hand's commanded state.
+        self._state_lock = threading.Lock()
+        self._desired_width: float | None = None
+        self._desired_lead_s = self._period
+        self._last_commanded: float | None = None
+        self._current_width: float | None = None
+        self._goal_in_flight = False
+        self._goal_sent_at: float | None = None
+
+        self.create_subscription(JointTrajectory, topic, self._on_target, 10, callback_group=self._cbgroup)
+        self.create_subscription(JointState, state_topic, self._on_state, 10, callback_group=self._cbgroup)
+        self.create_timer(self._period, self._tick, callback_group=self._cbgroup)
+
+        # Fail loudly at startup rather than on the first chunk.
+        for client, name in ((self._move, 'move'), (self._grasp, 'grasp')):
+            if not client.wait_for_server(timeout_sec=10.0):
+                self.get_logger().error(
+                    f'/fr3_gripper/{name} action server NOT found after 10s — is fr3-bringup running '
+                    'on this NUC, and was it started with load_gripper:=true (the default)?'
+                )
+            else:
+                self.get_logger().info(f'/fr3_gripper/{name} ready.')
+
+        mode = 'EXECUTE (fingers will move)' if self._execute else 'log-only (no motion)'
+        self.get_logger().info(f'fr3_gripper_bridge started — listening on {topic} — mode: {mode}')
+        self.get_logger().info(
+            f'rate limiting — deadband={self._deadband}m, min period={self._period}s, '
+            f'lead={self._lead_steps} steps, speed in [{self._min_speed}, {self._max_speed}] m/s'
+        )
+        grasp_mode = (
+            f'Grasp below {self._grasp_below}m ({self._grasp_force}N, eps={self._grasp_eps}m)'
+            if self._grasp_below > 0
+            else 'Move only — position control, applies NO force, will not hold an object'
+        )
+        self.get_logger().info(f'action selection — {grasp_mode}')
+
+    # ------------------------------------------------------------------
+    # Subscribers
+    # ------------------------------------------------------------------
+
+    def _on_state(self, msg: JointState) -> None:
+        """Cache the current aperture (each FR3 finger reports half of it)."""
+        if len(msg.position) < 2:
+            return
+        with self._state_lock:
+            self._current_width = float(msg.position[0] + msg.position[1])
+
+    def _on_target(self, msg: JointTrajectory) -> None:
+        """Record the latest desired width from a chunk; the timer decides whether to send it."""
+        if not msg.points:
+            self.get_logger().warning('Received empty gripper chunk, ignoring.')
+            return
+        idx = min(max(self._lead_steps, 0), len(msg.points) - 1)
+        point = msg.points[idx]
+        if not point.positions:
+            self.get_logger().warning('Gripper chunk point has no positions, ignoring.')
+            return
+        width = min(max(float(point.positions[0]), 0.0), self._max_width)
+        # How long the policy expects to take getting there — used to pick a move speed so the
+        # hand travels on roughly the intended timeline instead of always at one fixed rate.
+        lead_s = point.time_from_start.sec + point.time_from_start.nanosec * 1e-9
+        with self._state_lock:
+            self._desired_width = width
+            self._desired_lead_s = max(lead_s, self._period)
+
+    # ------------------------------------------------------------------
+    # Command loop
+    # ------------------------------------------------------------------
+
+    def _tick(self) -> None:
+        """Issue at most one gripper goal per period, and only if the target has really moved."""
+        now = time.monotonic()
+        with self._state_lock:
+            desired = self._desired_width
+            lead_s = self._desired_lead_s
+            current = self._current_width
+            last = self._last_commanded
+            in_flight = self._goal_in_flight
+            sent_at = self._goal_sent_at
+        if in_flight:
+            # Watchdog: a goal whose result never arrives would otherwise block every future
+            # command silently. Free the slot and say so.
+            if sent_at is not None and now - sent_at > GOAL_RESULT_TIMEOUT_S:
+                self.get_logger().warning(
+                    f'Gripper goal has been in flight for {now - sent_at:.1f}s with no result; '
+                    'releasing the slot. If this repeats, check that fr3-bringup is still up.'
+                )
+                self._clear_in_flight()
+            return
+        if desired is None:
+            return
+        if last is not None and abs(desired - last) < self._deadband:
+            return
+
+        speed = self._desired_speed(desired, current, lead_s)
+        use_grasp = (
+            self._grasp_below > 0.0
+            and desired < self._grasp_below
+            and current is not None
+            and desired < current
+        )
+        action = 'Grasp' if use_grasp else 'Move'
+        if not self._execute:
+            self.get_logger().info(
+                f'[log-only] would send {action}(width={desired:.4f}m, speed={speed:.3f}m/s)'
+            )
+            with self._state_lock:
+                self._last_commanded = desired
+            return
+
+        with self._state_lock:
+            self._goal_in_flight = True
+            self._goal_sent_at = now
+            self._last_commanded = desired
+        self.get_logger().info(f'{action}(width={desired:.4f}m, speed={speed:.3f}m/s)')
+        if use_grasp:
+            goal = Grasp.Goal()
+            goal.width = desired
+            goal.speed = speed
+            goal.force = self._grasp_force
+            goal.epsilon.inner = self._grasp_eps
+            goal.epsilon.outer = self._grasp_eps
+            self._send(self._grasp, goal, action)
+        else:
+            goal = Move.Goal()
+            goal.width = desired
+            goal.speed = speed
+            self._send(self._move, goal, action)
+
+    def _desired_speed(self, desired: float, current: float | None, lead_s: float) -> float:
+        """
+        Pick a move speed so the hand traverses roughly on the chunk's own timeline.
+
+        The closest discrete analogue to UMI's velocity-aware PD stream: we cannot command a
+        velocity profile, but we can at least size the single speed to the distance and the time
+        the policy allotted for it, instead of always moving at one fixed rate.
+        """
+        if current is None:
+            return self._max_speed
+        return min(max(abs(desired - current) / lead_s, self._min_speed), self._max_speed)
+
+    def _send(self, client: ActionClient, goal, label: str) -> None:
+        """Send a gripper goal and free the in-flight slot when it resolves."""
+        if not client.server_is_ready():
+            self.get_logger().error(f'{label} server not available; dropping goal.')
+            self._clear_in_flight()
+            return
+        future = client.send_goal_async(goal)
+        future.add_done_callback(lambda f: self._on_goal_response(f, label))
+
+    def _on_goal_response(self, future, label: str) -> None:
+        """Handle goal acceptance, then chain to the result."""
+        handle = future.result()
+        if handle is None or not handle.accepted:
+            self.get_logger().warning(f'{label} goal rejected.')
+            self._clear_in_flight()
+            return
+        handle.get_result_async().add_done_callback(lambda f: self._on_goal_result(f, label))
+
+    def _on_goal_result(self, future, label: str) -> None:
+        """
+        Log the outcome and free the slot.
+
+        A failed/aborted result is logged at INFO, not as an error: franka_gripper has no
+        preemption, so libfranka aborts whichever command the next goal supersedes, and a
+        moving target legitimately produces these. Treating them as faults would generate
+        exactly the log spam the rate limiting exists to prevent. A *steady stream* of them
+        still means the deadband or period is too small — see docs/crb-fr3-inference.md.
+        """
+        result = future.result()
+        if result is None:
+            self.get_logger().warning(f'{label} returned no result.')
+        elif not result.result.success:
+            self.get_logger().info(f'{label} did not complete: {result.result.error}')
+        self._clear_in_flight()
+
+    def _clear_in_flight(self) -> None:
+        """Release the single-goal slot so the next tick can command again."""
+        with self._state_lock:
+            self._goal_in_flight = False
+            self._goal_sent_at = None
+
+
+def main():
+    """Spin the bridge node under a multithreaded executor."""
+    rclpy.init()
+    node = Fr3GripperBridge()
+    executor = MultiThreadedExecutor()
+    executor.add_node(node)
+    try:
+        executor.spin()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/nuc/fr3_gripper_bridge.py
+++ b/nuc/fr3_gripper_bridge.py
@@ -58,9 +58,15 @@ GOAL_RESULT_TIMEOUT_S = 10.0
 class Fr3GripperBridge(Node):
     """Drive the Franka Hand from inference gripper-width chunks, deadbanded and rate-limited."""
 
-    def __init__(self):
-        """Declare params, create the target subscription and gripper action clients."""
-        super().__init__('fr3_gripper_bridge')
+    def __init__(self, **kwargs):
+        """
+        Declare params, create the target subscription and gripper action clients.
+
+        :param kwargs: forwarded to rclpy's Node — notably ``parameter_overrides``, so this node
+            can be constructed with specific values without a launch file (matching
+            polyumi_ros2's PolicyClientNode).
+        """
+        super().__init__('fr3_gripper_bridge', **kwargs)
 
         self.declare_parameter('execute', False)
         self.declare_parameter('target_topic', DEFAULT_TARGET_TOPIC)
@@ -100,13 +106,15 @@ class Fr3GripperBridge(Node):
         self._grasp_below = self.get_parameter('use_grasp_below_m').get_parameter_value().double_value
         self._grasp_force = self.get_parameter('grasp_force_n').get_parameter_value().double_value
         self._grasp_eps = self.get_parameter('grasp_epsilon_m').get_parameter_value().double_value
+        self._validate_params()
 
         self._cbgroup = ReentrantCallbackGroup()
         self._move = ActionClient(self, Move, '/fr3_gripper/move', callback_group=self._cbgroup)
         self._grasp = ActionClient(self, Grasp, '/fr3_gripper/grasp', callback_group=self._cbgroup)
 
-        # Latest-wins target; no queue. _last_commanded is what we actually sent (not what was
-        # last requested), so the deadband measures drift from the hand's commanded state.
+        # Latest-wins target; no queue. _last_commanded is what the hand actually *accepted* (not
+        # what was last requested, nor what was merely attempted), so the deadband measures drift
+        # from the hand's real commanded state and a goal that never landed stays retryable.
         self._state_lock = threading.Lock()
         self._desired_width: float | None = None
         self._desired_lead_s = self._period
@@ -141,6 +149,44 @@ class Fr3GripperBridge(Node):
             else 'Move only — position control, applies NO force, will not hold an object'
         )
         self.get_logger().info(f'action selection — {grasp_mode}')
+
+    def _validate_params(self) -> None:
+        """
+        Fail fast on parameter values that would break the command loop rather than error.
+
+        min_command_period_s is the sharp one: it is both the timer period and the floor on
+        _desired_lead_s, so a zero divides by zero inside _desired_speed — in a timer callback,
+        where the traceback scrolls past and the node then sits there commanding nothing. The
+        rest degrade quietly in the same spirit: a zero min_speed_mps issues goals the hand never
+        completes, an inverted speed range makes the clamp return the wrong bound.
+
+        :raises ValueError: on any out-of-range parameter.
+        """
+        errors = []
+        if self._period <= 0:
+            errors.append(f'min_command_period_s must be > 0, got {self._period}')
+        if self._deadband < 0:
+            errors.append(f'width_deadband_m must be >= 0, got {self._deadband}')
+        if self._max_width <= 0:
+            errors.append(f'max_width_m must be > 0, got {self._max_width}')
+        if self._lead_steps < 0:
+            errors.append(f'gripper_lead_steps must be >= 0, got {self._lead_steps}')
+        if self._min_speed <= 0:
+            errors.append(f'min_speed_mps must be > 0, got {self._min_speed}')
+        if self._max_speed < self._min_speed:
+            errors.append(
+                f'max_speed_mps ({self._max_speed}) must be >= min_speed_mps ({self._min_speed})'
+            )
+        if self._grasp_below < 0:
+            errors.append(f'use_grasp_below_m must be >= 0 (0 disables Grasp), got {self._grasp_below}')
+        if self._grasp_below > 0 and self._grasp_force <= 0:
+            errors.append(
+                f'grasp_force_n must be > 0 when use_grasp_below_m is set, got {self._grasp_force}'
+            )
+        if self._grasp_eps < 0:
+            errors.append(f'grasp_epsilon_m must be >= 0, got {self._grasp_eps}')
+        if errors:
+            raise ValueError('Invalid fr3_gripper_bridge configuration: ' + '; '.join(errors))
 
     # ------------------------------------------------------------------
     # Subscribers
@@ -178,27 +224,39 @@ class Fr3GripperBridge(Node):
     def _tick(self) -> None:
         """Issue at most one gripper goal per period, and only if the target has really moved."""
         now = time.monotonic()
+        # Read the state AND claim the in-flight slot in ONE critical section. The subscriptions
+        # and this timer share a ReentrantCallbackGroup under a MultiThreadedExecutor, so two
+        # ticks can genuinely overlap; checking the slot here and setting it further down would
+        # let both pass the guard and both send.
         with self._state_lock:
+            if self._goal_in_flight:
+                # Watchdog: a goal whose result never arrives would otherwise block every future
+                # command silently. Free the slot and say so; the next tick commands.
+                sent_at = self._goal_sent_at
+                if sent_at is not None and now - sent_at > GOAL_RESULT_TIMEOUT_S:
+                    self._goal_in_flight = False
+                    self._goal_sent_at = None
+                    self.get_logger().warning(
+                        f'Gripper goal has been in flight for {now - sent_at:.1f}s with no result; '
+                        'releasing the slot. If this repeats, check that fr3-bringup is still up.'
+                    )
+                return
             desired = self._desired_width
             lead_s = self._desired_lead_s
             current = self._current_width
             last = self._last_commanded
-            in_flight = self._goal_in_flight
-            sent_at = self._goal_sent_at
-        if in_flight:
-            # Watchdog: a goal whose result never arrives would otherwise block every future
-            # command silently. Free the slot and say so.
-            if sent_at is not None and now - sent_at > GOAL_RESULT_TIMEOUT_S:
-                self.get_logger().warning(
-                    f'Gripper goal has been in flight for {now - sent_at:.1f}s with no result; '
-                    'releasing the slot. If this repeats, check that fr3-bringup is still up.'
-                )
-                self._clear_in_flight()
-            return
-        if desired is None:
-            return
-        if last is not None and abs(desired - last) < self._deadband:
-            return
+            if desired is None:
+                return
+            if last is not None and abs(desired - last) < self._deadband:
+                return
+            if self._execute:
+                self._goal_in_flight = True
+                self._goal_sent_at = now
+                # NB: _last_commanded is deliberately NOT set here. It records what the hand was
+                # actually told, and the goal can still fail to go out (server gone) or be
+                # rejected. Setting it now would let the deadband suppress every retry until the
+                # policy's target drifted past it, parking the hand at a width it never received.
+                # _on_goal_response commits it once the goal is accepted.
 
         speed = self._desired_speed(desired, current, lead_s)
         use_grasp = (
@@ -212,14 +270,12 @@ class Fr3GripperBridge(Node):
             self.get_logger().info(
                 f'[log-only] would send {action}(width={desired:.4f}m, speed={speed:.3f}m/s)'
             )
+            # Nothing can fail in log-only mode, so commit immediately — this is what keeps a
+            # dry run's log deadbanded rather than one line per period.
             with self._state_lock:
                 self._last_commanded = desired
             return
 
-        with self._state_lock:
-            self._goal_in_flight = True
-            self._goal_sent_at = now
-            self._last_commanded = desired
         self.get_logger().info(f'{action}(width={desired:.4f}m, speed={speed:.3f}m/s)')
         if use_grasp:
             goal = Grasp.Goal()
@@ -228,12 +284,12 @@ class Fr3GripperBridge(Node):
             goal.force = self._grasp_force
             goal.epsilon.inner = self._grasp_eps
             goal.epsilon.outer = self._grasp_eps
-            self._send(self._grasp, goal, action)
+            self._send(self._grasp, goal, action, desired)
         else:
             goal = Move.Goal()
             goal.width = desired
             goal.speed = speed
-            self._send(self._move, goal, action)
+            self._send(self._move, goal, action, desired)
 
     def _desired_speed(self, desired: float, current: float | None, lead_s: float) -> float:
         """
@@ -247,22 +303,32 @@ class Fr3GripperBridge(Node):
             return self._max_speed
         return min(max(abs(desired - current) / lead_s, self._min_speed), self._max_speed)
 
-    def _send(self, client: ActionClient, goal, label: str) -> None:
-        """Send a gripper goal and free the in-flight slot when it resolves."""
+    def _send(self, client: ActionClient, goal, label: str, width: float) -> None:
+        """
+        Send a gripper goal and free the in-flight slot when it resolves.
+
+        :param width: the commanded aperture, carried through so _on_goal_response can record it
+            as _last_commanded only once the goal is accepted — a goal that never lands must stay
+            retryable rather than being deadbanded away.
+        """
         if not client.server_is_ready():
-            self.get_logger().error(f'{label} server not available; dropping goal.')
+            self.get_logger().error(f'{label} server not available; dropping goal (will retry).')
             self._clear_in_flight()
             return
         future = client.send_goal_async(goal)
-        future.add_done_callback(lambda f: self._on_goal_response(f, label))
+        future.add_done_callback(lambda f: self._on_goal_response(f, label, width))
 
-    def _on_goal_response(self, future, label: str) -> None:
-        """Handle goal acceptance, then chain to the result."""
+    def _on_goal_response(self, future, label: str, width: float) -> None:
+        """Handle goal acceptance, record what was commanded, then chain to the result."""
         handle = future.result()
         if handle is None or not handle.accepted:
-            self.get_logger().warning(f'{label} goal rejected.')
+            # Leave _last_commanded alone: the hand never got this width, so the next tick should
+            # be free to try again rather than treating it as already satisfied.
+            self.get_logger().warning(f'{label} goal rejected (will retry).')
             self._clear_in_flight()
             return
+        with self._state_lock:
+            self._last_commanded = width
         handle.get_result_async().add_done_callback(lambda f: self._on_goal_result(f, label))
 
     def _on_goal_result(self, future, label: str) -> None:

--- a/nuc/launch/fr3_bringup.launch.py
+++ b/nuc/launch/fr3_bringup.launch.py
@@ -1,0 +1,85 @@
+# PolyUMI: the FR3 *hardware session*, as one launch file.
+#
+# Replaces the two-terminal `fr3-bringup` + `fr3-arm-controller` alias dance. Those were split
+# only because the controller spawner has to run AFTER controller_manager exists — not because
+# they are independent things. They are one unit: restarting bringup tears down
+# controller_manager, which drops the controller, so the spawner has to run again anyway.
+#
+# What is deliberately NOT in here: move_group and the two PolyUMI bridges. Those live in
+# fr3_inference.launch.py, so this file can be restarted on its own — which matters, because
+# per docs/crb-fr3-inference.md ("TF lookup fails") this is the component that crashes
+# mid-session, and it is also the one gated on enabling FCI in the Desk UI by hand.
+
+"""
+Launch the FR3 hardware session: franka_bringup plus the arm controller.
+
+Run on the NUC, after enabling FCI on the Desk UI:
+
+    ros2 launch nuc/launch/fr3_bringup.launch.py
+
+See docs/crb-fr3-inference.md for the full bringup order and its gotchas.
+"""
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+
+# How long the spawner waits for controller_manager to appear. franka.launch.py brings the arm
+# up inside an OpaqueFunction, so there is no node handle here to hang an OnProcessStart event
+# on — upstream spawns its own broadcasters the same way, on the spawner's built-in wait. The
+# default (10s) is tight when the robot is cold, and overshooting costs nothing: the spawner
+# returns as soon as controller_manager answers.
+CONTROLLER_MANAGER_TIMEOUT_S = '60'
+
+
+def generate_launch_description():
+    """Include franka_bringup and spawn fr3_arm_controller once controller_manager is up."""
+    robot_ip = LaunchConfiguration('robot_ip')
+    arm_id = LaunchConfiguration('arm_id')
+    load_gripper = LaunchConfiguration('load_gripper')
+
+    return LaunchDescription([
+        DeclareLaunchArgument('robot_ip', default_value='192.168.51.20',
+                              description='Hostname or IP of the FR3 (the NUC-side .51 link).'),
+        DeclareLaunchArgument('arm_id', default_value='fr3',
+                              description='Arm type; drives every fr3_* frame and topic name.'),
+        # franka.launch.py defaults this to true as well. Named here because turning it off is
+        # what makes the /fr3_gripper/* action servers vanish — the first thing to check when
+        # the gripper bridge reports "action server NOT found".
+        DeclareLaunchArgument('load_gripper', default_value='true',
+                              description='Load the Franka Hand (the /fr3_gripper/* servers).'),
+
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource([PathJoinSubstitution(
+                [FindPackageShare('franka_bringup'), 'launch', 'franka.launch.py'])]),
+            launch_arguments={
+                'robot_ip': robot_ip,
+                'arm_id': arm_id,
+                'load_gripper': load_gripper,
+            }.items(),
+        ),
+
+        # The joint-trajectory controller move_group executes through. franka.launch.py spawns
+        # only the two broadcasters, so without this /execute_trajectory has nothing to drive
+        # and the arm never moves. --param-file declares the controller and its gains; -t is
+        # redundant alongside it but is what the known-good `fr3-arm-controller` alias passed,
+        # and this file only ever runs on the Humble NUC, whose spawner still accepts it.
+        Node(
+            package='controller_manager',
+            executable='spawner',
+            name='fr3_arm_controller_spawner',
+            output='screen',
+            arguments=[
+                'fr3_arm_controller',
+                '-t', 'joint_trajectory_controller/JointTrajectoryController',
+                '--param-file', PathJoinSubstitution([
+                    FindPackageShare('franka_fr3_moveit_config'),
+                    'config', 'fr3_ros_controllers.yaml',
+                ]),
+                '--controller-manager-timeout', CONTROLLER_MANAGER_TIMEOUT_S,
+            ],
+        ),
+    ])

--- a/nuc/launch/fr3_inference.launch.py
+++ b/nuc/launch/fr3_inference.launch.py
@@ -1,0 +1,75 @@
+# PolyUMI: everything the NUC needs for inference ON TOP of a running hardware session.
+#
+# Collapses three terminals (move_group + the two bridges) into one. All three are plain ROS
+# nodes with no hardware handshake, so they start together, fail together, and restart together
+# without touching the arm's state.
+#
+# They are separate from fr3_bringup.launch.py on purpose — see the note at the top of that
+# file. Start bringup first; this file's nodes all tolerate being started before their peers
+# (move_group waits, the bridges log a "server NOT found" error and keep spinning), but the
+# arm controller must already exist or move_group comes up with nothing to execute through.
+
+"""
+Launch the NUC-side inference stack: move_group plus the PolyUMI target bridges.
+
+Run on the NUC, after fr3_bringup.launch.py is up:
+
+    ros2 launch nuc/launch/fr3_inference.launch.py                       # dry run, nothing moves
+    ros2 launch nuc/launch/fr3_inference.launch.py execute_gripper:=true # fingers only
+    ros2 launch nuc/launch/fr3_inference.launch.py \
+        execute_arm:=true execute_gripper:=true max_velocity_scaling:=0.2
+
+See docs/crb-fr3-inference.md for the full bringup order and its gotchas.
+"""
+
+from pathlib import Path
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, ExecuteProcess, IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
+
+# The bridges are standalone scripts, not an installed ament package (they run from a plain
+# clone on the NUC, which has no PolyUMI workspace), so they are ExecuteProcess by path rather
+# than Node by package name.
+NUC_DIR = Path(__file__).resolve().parent.parent
+
+
+def generate_launch_description():
+    """Include move_group and start the gripper + MoveIt bridges."""
+    robot_ip = LaunchConfiguration('robot_ip')
+    execute_arm = LaunchConfiguration('execute_arm')
+    execute_gripper = LaunchConfiguration('execute_gripper')
+    max_velocity_scaling = LaunchConfiguration('max_velocity_scaling')
+
+    return LaunchDescription([
+        DeclareLaunchArgument('robot_ip', default_value='192.168.51.20',
+                              description='Hostname or IP of the FR3; forwarded to move_group.'),
+        # Two execute flags, not one. docs/crb-fr3-inference.md recommends running the arm
+        # plan-only while the gripper executes for a first hardware run, so a bad width moves
+        # fingers and nothing else — a single shared flag would take that away. Both default
+        # false: launching this file must never move the robot on its own.
+        DeclareLaunchArgument('execute_arm', default_value='false',
+                              description='Let fr3_moveit_bridge execute plans (MOVES THE ARM).'),
+        DeclareLaunchArgument('execute_gripper', default_value='false',
+                              description='Let fr3_gripper_bridge send goals (MOVES THE FINGERS).'),
+        DeclareLaunchArgument('max_velocity_scaling', default_value='0.1',
+                              description='Arm speed cap. Start low, raise once you trust it.'),
+
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(str(NUC_DIR / 'launch' / 'fr3_move_group.launch.py')),
+            launch_arguments={'robot_ip': robot_ip}.items(),
+        ),
+
+        ExecuteProcess(
+            cmd=['python3', str(NUC_DIR / 'fr3_moveit_bridge.py'), '--ros-args',
+                 '-p', ['execute:=', execute_arm],
+                 '-p', ['max_velocity_scaling:=', max_velocity_scaling]],
+            output='screen',
+        ),
+        ExecuteProcess(
+            cmd=['python3', str(NUC_DIR / 'fr3_gripper_bridge.py'), '--ros-args',
+                 '-p', ['execute:=', execute_gripper]],
+            output='screen',
+        ),
+    ])

--- a/nuc/test_fr3_gripper_bridge.py
+++ b/nuc/test_fr3_gripper_bridge.py
@@ -1,0 +1,390 @@
+"""
+Tests for the NUC-side gripper bridge's command loop.
+
+This is where every stateful decision on the gripper path lives — the single in-flight goal
+slot, the watchdog that frees it, the deadband, and the deferred _last_commanded commit — and
+all of it fails *quietly*: a wedged slot just stops commanding, a mis-committed _last_commanded
+just parks the hand at a width it never received. Nothing raises, so nothing shows up in a log
+except an absence.
+
+Runs on the laptop despite the bridge targeting the Humble NUC: only the franka_msgs *message
+definitions* are needed, and those are built in ros2_ws. No action servers are involved — the
+ActionClient is mocked out, so these tests exercise the bridge's logic and nothing else.
+
+    bash -c 'unset VIRTUAL_ENV; source /opt/ros/kilted/setup.bash \
+      && source ros2_ws/install/setup.bash \
+      && /usr/bin/python3 -m pytest nuc/test_fr3_gripper_bridge.py -q'
+"""
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+import rclpy
+from rclpy.duration import Duration
+from rclpy.parameter import Parameter
+from sensor_msgs.msg import JointState
+from trajectory_msgs.msg import JointTrajectory, JointTrajectoryPoint
+
+import fr3_gripper_bridge as gb
+
+
+@pytest.fixture(scope='module', autouse=True)
+def ros():
+    """Init rclpy once for the module; every node here is constructed without a real executor."""
+    rclpy.init()
+    yield
+    rclpy.shutdown()
+
+
+@pytest.fixture
+def make_node():
+    """
+    Build a bridge with mocked action clients, so no server or executor is required.
+
+    wait_for_server/server_is_ready both answer True: the tests that care about an absent server
+    override them explicitly, and the rest should not have to.
+    """
+    nodes = []
+
+    def _make(**overrides):
+        params = [Parameter(k, value=v) for k, v in overrides.items()]
+        with patch.object(gb, 'ActionClient') as action_client:
+            action_client.return_value.wait_for_server.return_value = True
+            action_client.return_value.server_is_ready.return_value = True
+            node = gb.Fr3GripperBridge(parameter_overrides=params)
+        node.get_logger = MagicMock()
+        nodes.append(node)
+        return node
+
+    yield _make
+    for node in nodes:
+        node.destroy_node()
+
+
+def _chunk(widths, dt=0.1) -> JointTrajectory:
+    """Build a gripper chunk as policy_client_node publishes one: one point per action step."""
+    msg = JointTrajectory()
+    msg.joint_names = ['fr3_gripper_width']
+    for i, width in enumerate(widths):
+        point = JointTrajectoryPoint()
+        point.positions = [width]
+        point.time_from_start = Duration(seconds=i * dt).to_msg()
+        msg.points.append(point)
+    return msg
+
+
+def _capture_sends(node) -> list:
+    """Replace _send with a recorder, returning the list it appends (label, goal, width) to."""
+    sent = []
+    node._send = lambda client, goal, label, width: sent.append((label, goal, width))
+    return sent
+
+
+def _push_state(node, width_m: float) -> None:
+    """Feed one gripper joint state, split across the two fingers as the FR3 reports it."""
+    msg = JointState()
+    msg.position = [width_m / 2.0, width_m / 2.0]
+    node._on_state(msg)
+
+
+# ----------------------------------------------------------------------
+# Target intake
+# ----------------------------------------------------------------------
+
+
+def test_state_sums_the_two_finger_joints(make_node):
+    """Aperture is the SUM of the finger positions — each reports half the opening."""
+    node = make_node()
+    _push_state(node, 0.06)
+
+    assert node._current_width == pytest.approx(0.06)
+
+
+def test_lead_steps_selects_a_later_point_and_clamps(make_node):
+    """gripper_lead_steps indexes into the chunk, saturating at the last point rather than raising."""
+    node = make_node(gripper_lead_steps=2)
+    node._on_target(_chunk([0.01, 0.02, 0.03, 0.04]))
+    assert node._desired_width == pytest.approx(0.03)
+
+    far = make_node(gripper_lead_steps=99)
+    far._on_target(_chunk([0.01, 0.02, 0.03]))
+    assert far._desired_width == pytest.approx(0.03)
+
+
+def test_target_width_is_clamped_to_the_robot_range(make_node):
+    """The handheld gripper opens wider than the hand, and a negative width is meaningless."""
+    node = make_node(max_width_m=0.08)
+    node._on_target(_chunk([0.5]))
+    assert node._desired_width == pytest.approx(0.08)
+
+    node._on_target(_chunk([-0.2]))
+    assert node._desired_width == pytest.approx(0.0)
+
+
+def test_degenerate_chunks_are_ignored(make_node):
+    """An empty chunk, or a point with no positions, leaves the last target standing."""
+    node = make_node()
+    node._on_target(_chunk([0.03]))
+
+    node._on_target(JointTrajectory())
+    empty_point = JointTrajectory()
+    empty_point.points.append(JointTrajectoryPoint())
+    node._on_target(empty_point)
+
+    assert node._desired_width == pytest.approx(0.03)
+
+
+# ----------------------------------------------------------------------
+# Command loop: deadband and the in-flight slot
+# ----------------------------------------------------------------------
+
+
+def test_deadband_suppresses_a_repeat_command(make_node):
+    """
+    A target that has not moved past the deadband issues nothing.
+
+    This is the whole point of the rate limiting: franka_gripper accepts every goal into a
+    detached thread with no queue, so an unfiltered 10 Hz stream is ~9 aborted goals a second.
+    """
+    node = make_node(execute=False, width_deadband_m=0.005)
+    node._on_target(_chunk([0.05]))
+    node._tick()
+    node._on_target(_chunk([0.052]))  # 2mm — inside the deadband
+    node._tick()
+
+    logged = [c for c in node.get_logger().info.call_args_list if 'log-only' in str(c)]
+    assert len(logged) == 1
+
+
+def test_a_move_past_the_deadband_commands_again(make_node):
+    """Once the target really has moved, the next tick commands."""
+    node = make_node(execute=False, width_deadband_m=0.005)
+    node._on_target(_chunk([0.05]))
+    node._tick()
+    node._on_target(_chunk([0.07]))
+    node._tick()
+
+    logged = [c for c in node.get_logger().info.call_args_list if 'log-only' in str(c)]
+    assert len(logged) == 2
+
+
+def test_only_one_goal_is_in_flight_at_a_time(make_node):
+    """A second tick while a goal is unresolved sends nothing — the slot is claimed."""
+    node = make_node(execute=True)
+    sent = _capture_sends(node)
+    node._on_target(_chunk([0.05]))
+
+    node._tick()
+    node._on_target(_chunk([0.02]))  # well past the deadband
+    node._tick()
+
+    assert len(sent) == 1
+
+
+def test_watchdog_frees_a_slot_whose_goal_never_resolved(make_node):
+    """
+    A goal that never resolves must not wedge the bridge permanently.
+
+    Goal resolution is callback-driven, so a lost result callback (server died mid-motion) would
+    otherwise stop the bridge commanding forever, and silently.
+    """
+    node = make_node(execute=True)
+    sent = _capture_sends(node)
+    node._on_target(_chunk([0.05]))
+    node._tick()
+    assert node._goal_in_flight
+
+    node._goal_sent_at = time.monotonic() - (gb.GOAL_RESULT_TIMEOUT_S + 1.0)
+    node._tick()  # notices the timeout, frees the slot, commands on the NEXT tick
+    assert not node._goal_in_flight
+    assert len(sent) == 1
+
+    node._tick()
+    assert len(sent) == 2
+
+
+def test_log_only_mode_never_claims_the_slot(make_node):
+    """A dry run must keep logging every distinct width, not stall behind a phantom goal."""
+    node = make_node(execute=False)
+    node._on_target(_chunk([0.05]))
+    node._tick()
+
+    assert not node._goal_in_flight
+    assert node._last_commanded == pytest.approx(0.05)
+
+
+# ----------------------------------------------------------------------
+# Goal resolution: what gets committed to _last_commanded, and when
+# ----------------------------------------------------------------------
+
+
+def _goal_response(accepted: bool):
+    """Build a fake send_goal_async future that resolves to an accepted/rejected goal handle."""
+    future = MagicMock()
+    handle = MagicMock()
+    handle.accepted = accepted
+    future.result.return_value = handle
+    return future, handle
+
+
+def test_last_commanded_is_committed_only_on_acceptance(make_node):
+    """The deadband measures drift from what the hand actually accepted, not what we attempted."""
+    node = make_node(execute=True)
+    node._goal_in_flight = True
+    future, _ = _goal_response(accepted=True)
+
+    node._on_goal_response(future, 'Move', width=0.05)
+
+    assert node._last_commanded == pytest.approx(0.05)
+
+
+def test_a_rejected_goal_stays_retryable(make_node):
+    """
+    A goal the hand never got must not be deadbanded away.
+
+    Committing _last_commanded on send would suppress every retry until the policy's target
+    drifted a full deadband, parking the hand at a width it was never told about.
+    """
+    node = make_node(execute=True)
+    node._goal_in_flight = True
+    future, _ = _goal_response(accepted=False)
+
+    node._on_goal_response(future, 'Move', width=0.05)
+
+    assert node._last_commanded is None
+    assert not node._goal_in_flight
+
+
+def test_a_send_failure_frees_the_slot_instead_of_wedging_it(make_node):
+    """
+    A send whose future carries an exception must free the slot, not escape the callback.
+
+    rclpy's Future.result() re-raises what the send stored rather than returning None.
+
+    Unguarded, the raise escapes into rclpy internals and _clear_in_flight never runs — the
+    bridge then stops commanding for a full GOAL_RESULT_TIMEOUT_S, with nothing in the log to
+    say why.
+    """
+    node = make_node(execute=True)
+    node._goal_in_flight = True
+    future = MagicMock()
+    future.result.side_effect = RuntimeError('send failed')
+
+    node._on_goal_response(future, 'Move', width=0.05)
+
+    assert not node._goal_in_flight
+    assert node._last_commanded is None
+
+
+def test_a_raising_result_future_frees_the_slot_too(make_node):
+    """Same guarantee on the result half of the handshake."""
+    node = make_node(execute=True)
+    node._goal_in_flight = True
+    future = MagicMock()
+    future.result.side_effect = RuntimeError('result failed')
+
+    node._on_goal_result(future, 'Move')
+
+    assert not node._goal_in_flight
+
+
+def test_an_unavailable_server_drops_the_goal_and_frees_the_slot(make_node):
+    """A dropped goal has to leave the bridge able to retry, not holding a claimed slot."""
+    node = make_node(execute=True)
+    node._goal_in_flight = True
+    node._move.server_is_ready.return_value = False
+
+    node._send(node._move, gb.Move.Goal(), 'Move', width=0.05)
+
+    assert not node._goal_in_flight
+    assert node._last_commanded is None
+
+
+# ----------------------------------------------------------------------
+# Action selection and speed
+# ----------------------------------------------------------------------
+
+
+def test_speed_is_derived_from_distance_and_the_chunk_timeline(make_node):
+    """Speed sizes to the move, clamped into the configured band at both ends."""
+    node = make_node(min_speed_mps=0.02, max_speed_mps=0.15)
+
+    assert node._desired_speed(0.05, 0.04, 0.25) == pytest.approx(0.04)  # 0.01m / 0.25s
+    assert node._desired_speed(0.041, 0.04, 0.25) == pytest.approx(0.02)  # clamped to min
+    assert node._desired_speed(0.08, 0.0, 0.25) == pytest.approx(0.15)  # clamped to max
+
+
+def test_speed_falls_back_to_the_maximum_without_a_state_reading(make_node):
+    """With no measured width there is no distance to size against."""
+    node = make_node(max_speed_mps=0.15)
+
+    assert node._desired_speed(0.05, None, 0.25) == pytest.approx(0.15)
+
+
+def test_grasp_is_used_only_when_closing_below_the_threshold(make_node):
+    """
+    Grasp (force-controlled) applies only on a CLOSING move below the threshold.
+
+    Move applies no force, so opening or moving above the threshold must stay a Move — a Grasp
+    on an opening command would squeeze against nothing.
+    """
+    node = make_node(execute=True, use_grasp_below_m=0.03, width_deadband_m=0.001)
+    sent = _capture_sends(node)
+
+    _push_state(node, 0.06)
+    node._on_target(_chunk([0.02]))  # closing, below the threshold
+    node._tick()
+    assert sent[-1][0] == 'Grasp'
+
+    node._clear_in_flight()
+    _push_state(node, 0.01)
+    node._on_target(_chunk([0.025]))  # below the threshold but OPENING
+    node._tick()
+    assert sent[-1][0] == 'Move'
+
+
+def test_grasp_is_disabled_by_default(make_node):
+    """
+    The shipped default is Move-only: bringup moves fingers and applies no force.
+
+    use_grasp_below_m defaults to 0.0 precisely so a first hardware run cannot squeeze anything.
+    """
+    node = make_node(execute=True)
+    sent = _capture_sends(node)
+
+    _push_state(node, 0.06)
+    node._on_target(_chunk([0.0]))
+    node._tick()
+
+    assert sent[-1][0] == 'Move'
+
+
+# ----------------------------------------------------------------------
+# Parameter validation
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    'bad',
+    [
+        {'min_command_period_s': 0.0},  # divides by zero inside _desired_speed
+        {'min_speed_mps': 0.0},  # issues goals the hand never completes
+        {'max_speed_mps': 0.01},  # inverted range: the clamp returns the wrong bound
+        {'width_deadband_m': -0.001},
+        {'max_width_m': 0.0},
+        {'gripper_lead_steps': -1},
+        {'use_grasp_below_m': -0.01},
+        {'use_grasp_below_m': 0.03, 'grasp_force_n': 0.0},
+        {'grasp_epsilon_m': -0.01},
+    ],
+)
+def test_invalid_parameters_fail_fast(make_node, bad):
+    """
+    Bad configuration raises at construction rather than degrading inside a timer callback.
+
+    The sharp one is min_command_period_s: a zero divides by zero in _desired_speed, inside a
+    timer callback, where the traceback scrolls past and the node then sits commanding nothing.
+    """
+    with pytest.raises(ValueError, match='Invalid fr3_gripper_bridge configuration'):
+        make_node(**bad)

--- a/ros2_ws/src/polyumi_pi_msgs/pyproject.toml
+++ b/ros2_ws/src/polyumi_pi_msgs/pyproject.toml
@@ -2,21 +2,21 @@
 requires = [
     "setuptools>=68",
     "wheel",
-    "grpcio-tools>=1.78.0",
-    # Pinned to match the RUNTIME constraint everywhere this package is actually used
-    # (pi/pyproject.toml, this package's own [project] deps below: protobuf>=6,<7).
-    # Without this, pip/uv's build-isolation resolver is free to pick whatever grpcio-tools
-    # is newest on PyPI, and that bundles ITS OWN protoc — which stamps generated _pb2.py
-    # files with a gencode-version marker tied to grpcio-tools' bundled protobuf, entirely
-    # independent of the runtime pin below. A too-new stamp fails at IMPORT time on any
-    # machine whose installed protobuf is older than the gencode marker (breaks all-or-
-    # nothing, unlike most version skew): "Detected incompatible Protobuf Gencode/Runtime
-    # versions ... Runtime version cannot be older than the linked gencode version." This bit
-    # the Pi for real — a PEP-517 build (uv run/uv sync touching this editable dependency,
-    # or `pip install`/`python -m build` directly) pulled a fresh grpcio-tools whose bundled
-    # protoc stamped gencode 7.35.1, while pi/.venv's pinned runtime was 6.33.6. `colcon
-    # build`'s direct setup.py invocation (see setup.py's compile_protos()) doesn't hit this,
-    # since it never triggers build isolation — only PEP 517 entry points do.
+    # WHAT BREAKS IF YOU LOOSEN THIS CEILING. grpcio-tools bundles its own protoc, which stamps
+    # every generated _pb2.py with a gencode version. protobuf REFUSES AT IMPORT to load gencode
+    # newer than the installed runtime ("Runtime version cannot be older than the linked gencode
+    # version") — all-or-nothing, unlike most version skew, so it takes down every polyumi-pi
+    # command at once. This bit the Pi for real: a PEP-517 build pulled grpcio-tools 1.82.1,
+    # whose protoc stamps gencode 7.35.1, against pi/.venv's protobuf 6.33.6.
+    #
+    # 1.82.1 is the first release to stamp 7.x, so that is the cap. Raise it only together with
+    # the protobuf runtime pin in pi/pyproject.toml, and re-run ./deploy.sh — its import check
+    # on the Pi is what actually proves the pair agrees.
+    "grpcio-tools>=1.78.0,<1.82.1",
+    # Belt to the cap's braces, and the runtime constraint this package declares anyway. NOTE it
+    # does NOT by itself keep grpcio-tools in range: 1.82.0 declares `protobuf<8,>=6.33.5`, which
+    # a resolver satisfies at 6.x while still shipping a newer bundled protoc. Constraining the
+    # gencode means constraining grpcio-tools directly — hence the cap above.
     "protobuf>=6,<7",
 ]
 build-backend = "setuptools.build_meta"

--- a/ros2_ws/src/polyumi_pi_msgs/pyproject.toml
+++ b/ros2_ws/src/polyumi_pi_msgs/pyproject.toml
@@ -3,6 +3,20 @@ requires = [
     "setuptools>=68",
     "wheel",
     "grpcio-tools>=1.78.0",
-    "protobuf",
+    # Pinned to match the RUNTIME constraint everywhere this package is actually used
+    # (pi/pyproject.toml, this package's own [project] deps below: protobuf>=6,<7).
+    # Without this, pip/uv's build-isolation resolver is free to pick whatever grpcio-tools
+    # is newest on PyPI, and that bundles ITS OWN protoc — which stamps generated _pb2.py
+    # files with a gencode-version marker tied to grpcio-tools' bundled protobuf, entirely
+    # independent of the runtime pin below. A too-new stamp fails at IMPORT time on any
+    # machine whose installed protobuf is older than the gencode marker (breaks all-or-
+    # nothing, unlike most version skew): "Detected incompatible Protobuf Gencode/Runtime
+    # versions ... Runtime version cannot be older than the linked gencode version." This bit
+    # the Pi for real — a PEP-517 build (uv run/uv sync touching this editable dependency,
+    # or `pip install`/`python -m build` directly) pulled a fresh grpcio-tools whose bundled
+    # protoc stamped gencode 7.35.1, while pi/.venv's pinned runtime was 6.33.6. `colcon
+    # build`'s direct setup.py invocation (see setup.py's compile_protos()) doesn't hit this,
+    # since it never triggers build isolation — only PEP 517 entry points do.
+    "protobuf>=6,<7",
 ]
 build-backend = "setuptools.build_meta"

--- a/ros2_ws/src/polyumi_pi_msgs/setup.py
+++ b/ros2_ws/src/polyumi_pi_msgs/setup.py
@@ -10,25 +10,46 @@ package_name = 'polyumi_pi_msgs'
 
 
 def compile_protos():
-    """Compile the protobuf files."""
+    """
+    Compile the protobuf files, generating .pyi type stubs when protoc supports them.
+
+    The .pyi stubs need protoc's built-in --pyi_out generator, added in protobuf 3.20. We ask
+    for it via grpcio-tools>=1.78 in this package's [build-system] requires, but that is only
+    honoured by PEP 517 builds (pip install / python -m build). **colcon's ament_python build
+    type runs this setup.py directly with the system interpreter**, so under `colcon build` the
+    requirement is never installed and `grpc_tools` resolves to whatever the distro ships — on
+    Ubuntu 24.04 that is grpcio-tools 1.14.1, bundling libprotoc 3.5.1. That protoc has no
+    built-in pyi generator, so it looks for a `protoc-gen-pyi` plugin, finds none, and the whole
+    build fails.
+
+    The stubs are type hints only — nothing imports them at runtime — so a missing pyi generator
+    should not break the build. Try with --pyi_out, and on failure fall back to generating just
+    the _pb2.py modules with a warning. Version-sniffing protoc is avoided deliberately: its
+    scheme has changed twice (3.20 -> 4.21 -> 25.x), whereas "try it and see" is version-proof.
+    """
     package_dir = Path(__file__).resolve().parent
     proto_root = package_dir / package_name
     proto_files = sorted(proto_root.glob('*.proto'))
 
-    # Use the protoc bundled with grpcio-tools (a build dependency) rather than
-    # the system protoc, which may be too old to support the built-in --pyi_out
-    # generator (added in protobuf 3.20).
+    base_cmd = [sys.executable, '-m', 'grpc_tools.protoc', f'-I={proto_root}']
+    with_stubs = True
     for proto_file in proto_files:
-        proto_cmd = [
-            sys.executable,
-            '-m',
-            'grpc_tools.protoc',
-            f'-I={proto_root}',
-            f'--pyi_out={proto_root}',
-            f'--python_out={proto_root}',
-            str(proto_file),
-        ]
-        subprocess.run(proto_cmd, check=True)
+        args = [f'--python_out={proto_root}', str(proto_file)]
+        if with_stubs:
+            result = subprocess.run(base_cmd + [f'--pyi_out={proto_root}'] + args)
+            if result.returncode == 0:
+                continue
+            # Don't retry the probe for each remaining file — one failure settles it.
+            with_stubs = False
+            print(
+                f'WARNING: {package_name}: protoc cannot generate .pyi stubs (needs protobuf '
+                f'>= 3.20; this interpreter has an older grpc_tools). Falling back to _pb2.py '
+                f'only — type hints will be stale or absent, but runtime is unaffected. '
+                f'For stubs, build this package with pip/uv (which honours [build-system] '
+                f'requires) or install a newer grpcio-tools for {sys.executable}.',
+                file=sys.stderr,
+            )
+        subprocess.run(base_cmd + args, check=True)
 
 
 compile_protos()

--- a/ros2_ws/src/polyumi_ros2/config/inference.yaml
+++ b/ros2_ws/src/polyumi_ros2/config/inference.yaml
@@ -20,8 +20,7 @@
       # Delay from a photon hitting the GoPro sensor to the frame's ROS header stamp:
       # GoPro encode + HDMI out + capture card + USB + v4l2 dequeue. Sets both the TF lookup
       # instant and t_obs for chunk truncation, so it is the most load-bearing value here.
-      # 0.05 is a guess and probably low — UMI measured 0.125-0.17s for a plain UVC webcam,
-      # and this path is longer than that.
+      # Unmeasured - guess (TODO measure)
       gopro: 0.13
       # Finger camera latency. Declared but never consumed — the policy has no tactile input
       # yet (blocking issue 4). Left at 0 so it cannot skew anything until it is wired.
@@ -35,8 +34,8 @@
       # Delay from the hand's true aperture to it appearing on /fr3_gripper/joint_states.
       # Kept separate from proprio because the gripper is a different device on its own link and
       # its own (slower, jitterier) topic — UMI splits these too (gripper_action_latency vs
-      # robot_action_latency). Unmeasured; the topic jitters 24-100 ms, so 0 is certainly wrong,
-      # but a wrong non-zero guess is worse than a known-zero placeholder.
+      # robot_action_latency). 
+      # Unmeasured - placeholder guess.
       gripper: 0.05
 
     # --- Gripper width conversion. ---

--- a/ros2_ws/src/polyumi_ros2/config/inference.yaml
+++ b/ros2_ws/src/polyumi_ros2/config/inference.yaml
@@ -34,7 +34,7 @@
       # Delay from the hand's true aperture to it appearing on /fr3_gripper/joint_states.
       # Kept separate from proprio because the gripper is a different device on its own link and
       # its own (slower, jitterier) topic — UMI splits these too (gripper_action_latency vs
-      # robot_action_latency). 
+      # robot_action_latency).
       # Unmeasured - placeholder guess.
       gripper: 0.05
 

--- a/ros2_ws/src/polyumi_ros2/config/inference.yaml
+++ b/ros2_ws/src/polyumi_ros2/config/inference.yaml
@@ -22,22 +22,22 @@
       # instant and t_obs for chunk truncation, so it is the most load-bearing value here.
       # 0.05 is a guess and probably low — UMI measured 0.125-0.17s for a plain UVC webcam,
       # and this path is longer than that.
-      gopro: 0.05
+      gopro: 0.13
       # Finger camera latency. Declared but never consumed — the policy has no tactile input
       # yet (blocking issue 4). Left at 0 so it cannot skew anything until it is wired.
       finger_cam: 0.0
       # Piezo mic latency. Declared but never consumed, as above.
       piezo_mic: 0.0
       # Delay from the arm's true EE pose to its measurement appearing on TF.
-      proprio: 0.01
+      proprio: 0.03
       # Delay from publishing a target pose to the arm actually starting to move.
-      arm_exec: 0.01
+      arm_exec: 0.03
       # Delay from the hand's true aperture to it appearing on /fr3_gripper/joint_states.
       # Kept separate from proprio because the gripper is a different device on its own link and
       # its own (slower, jitterier) topic — UMI splits these too (gripper_action_latency vs
       # robot_action_latency). Unmeasured; the topic jitters 24-100 ms, so 0 is certainly wrong,
       # but a wrong non-zero guess is worse than a known-zero placeholder.
-      gripper: 0.0
+      gripper: 0.05
 
     # --- Gripper width conversion. ---
     # The policy speaks ArUco finger-tag separation (what ingest step 4 measures); the robot

--- a/ros2_ws/src/polyumi_ros2/config/inference.yaml
+++ b/ros2_ws/src/polyumi_ros2/config/inference.yaml
@@ -32,6 +32,28 @@
       proprio: 0.01
       # Delay from publishing a target pose to the arm actually starting to move.
       arm_exec: 0.01
+      # Delay from the hand's true aperture to it appearing on /fr3_gripper/joint_states.
+      # Kept separate from proprio because the gripper is a different device on its own link and
+      # its own (slower, jitterier) topic — UMI splits these too (gripper_action_latency vs
+      # robot_action_latency). Unmeasured; the topic jitters 24-100 ms, so 0 is certainly wrong,
+      # but a wrong non-zero guess is worse than a known-zero placeholder.
+      gripper: 0.0
+
+    # --- Gripper width conversion. ---
+    # The policy speaks ArUco finger-tag separation (what ingest step 4 measures); the robot
+    # speaks jaw aperture. The conversion is a constant subtraction, following UMI — see
+    # polyumi_ros2/gripper_map.py and docs/franka-inference-bringup.md ("Phase 2.5").
+    #
+    # !!! NEVER MEASURED. !!! This is gripper_calib.yaml's closed_mm (5 mm), a value no code
+    # reads and nobody has checked against a closing video. UMI derives its equivalent
+    # empirically (scripts/calibrate_gripper_range.py takes the minimum tag separation over a
+    # video in which the gripper fully closes); we have no such script yet. If commanded widths
+    # look systematically too open or too closed, this is the first number to suspect.
+    gripper_offset_m: 0.005
+    # Commanded aperture clamps here. The FR3 hand reads ~0.0817 m fully open, but franka_gripper
+    # does not publish max_width on any topic, so it cannot be read back at runtime.
+    gripper_max_width_m: 0.08
+
     buffers:
       # How far back (seconds) the EE-pose TF buffer retains history, so a past pose can
       # still be looked up/interpolated to align with a delayed observation (e.g. the gopro

--- a/ros2_ws/src/polyumi_ros2/package.xml
+++ b/ros2_ws/src/polyumi_ros2/package.xml
@@ -31,6 +31,12 @@
        does the actual MoveIt calls — moveit_msgs is NOT needed on the laptop (large
        MoveIt action goals corrupt across the laptop/NUC rmw-version gap). -->
   <depend>geometry_msgs</depend>
+  <!-- Phase 2.5: the gripper half of the action chunk goes out separately, as a
+       trajectory_msgs/JointTrajectory on /polyumi/target_gripper. A PoseArray cannot carry a
+       width, and the Franka Hand is action-only (no ros2_control interface), so it needs its
+       own channel and its own cadence. Consumed by nuc/fr3_gripper_bridge.py — the franka_msgs
+       gripper actions are called from the NUC, not here. -->
+  <depend>trajectory_msgs</depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/ros2_ws/src/polyumi_ros2/polyumi_ros2/gripper_map.py
+++ b/ros2_ws/src/polyumi_ros2/polyumi_ros2/gripper_map.py
@@ -1,0 +1,56 @@
+"""
+The gripper-width contract between policy units and robot units.
+
+The policy speaks in the units of the training data: the x-separation of the two ArUco finger
+tags, as measured from GoPro video by ingest step 4 (``annotations/gripper_width/width_m``). That
+is *not* jaw aperture — the tags sit on the outer faces of the fingers, so a fully-closed handheld
+gripper still measures a few millimetres. The robot speaks in true aperture, where closed is 0.
+
+The conversion is a **constant subtraction with slope 1**, following UMI. Their
+``get_gripper_calibration_interpolator`` (``umi/common/interpolation_util.py``) computes
+``aruco_actual_width - aruco_min_width``, and ``06_generate_dataset_plan.py`` passes the same
+array as both of its arguments — so despite the ``interp1d`` machinery the map reduces to an
+offset, with no rescaling. UMI measures that offset empirically as the minimum tag separation over
+a calibration video in which the gripper fully closes (``scripts/calibrate_gripper_range.py``).
+
+Two caveats worth knowing before trusting a number that comes out of here:
+
+- **The offset PolyUMI uses is declared, not measured.** It defaults to ``gripper_calib.yaml``'s
+  ``closed_mm``, a value no code has ever read. Writing our equivalent of UMI's calibration script
+  is tracked in docs/franka-inference-bringup.md (Phase 2.5).
+- **This aligns the zero point, not the stroke.** The handheld gripper can open wider than the
+  Franka Hand's ~0.0817 m, so commands past ``max_width_m`` clamp — which shows up as the policy's
+  intent saturating, not as an error.
+
+The principled home for this subtraction is *ingest*, not inference: UMI applies it at
+dataset-generation time, so its stored widths are already aperture and its inference path converts
+nothing. Moving ours there is deferred to the exporter rework, since it invalidates existing
+exports.
+"""
+
+
+def policy_to_robot_width(width_m: float, offset_m: float, max_width_m: float) -> float:
+    """
+    Convert a policy-space width (ArUco tag separation) to a commandable jaw aperture.
+
+    :param width_m: width in training units, i.e. finger-tag separation in metres.
+    :param offset_m: tag separation with the gripper fully closed; subtracted off.
+    :param max_width_m: the robot's maximum aperture; the result is clamped into [0, this].
+    :returns: jaw aperture in metres, clamped to the robot's reachable range.
+    """
+    return min(max(width_m - offset_m, 0.0), max_width_m)
+
+
+def robot_to_policy_width(width_m: float, offset_m: float) -> float:
+    """
+    Convert a measured jaw aperture back into policy-space width.
+
+    The inverse of :func:`policy_to_robot_width` up to clamping — deliberately *not* clamped here,
+    because an out-of-range observation is real information about the robot and silently squashing
+    it would hide a miscalibrated offset from the policy.
+
+    :param width_m: jaw aperture in metres (for the FR3, ``position[0] + position[1]``).
+    :param offset_m: tag separation with the gripper fully closed; added back on.
+    :returns: width in training units, i.e. finger-tag separation in metres.
+    """
+    return width_m + offset_m

--- a/ros2_ws/src/polyumi_ros2/polyumi_ros2/policy_client_node.py
+++ b/ros2_ws/src/polyumi_ros2/polyumi_ros2/policy_client_node.py
@@ -13,9 +13,13 @@ At each control tick the node:
      previously published chunk, matching UMI (infer once per ~steps_per_inference*dt).
   4. Drops the leading actions of the returned chunk that are already stale by the time the
      arm could act on them (observation + inference + arm-execution latency).
-  5. Logs the chunk. If execute_motion is set, publishes the remaining chunk as a PoseArray
-     on /polyumi/target_poses for the NUC-side fr3_moveit_bridge to plan+execute as one
-     Cartesian path (receding-horizon control) — see docs/crb-fr3-inference.md.
+  5. Logs the chunk. If execute_motion is set, publishes the remaining chunk on two topics for
+     the NUC-side bridges: the pose half as a PoseArray on /polyumi/target_poses (planned and
+     executed as one Cartesian path by fr3_moveit_bridge, receding-horizon control), and the
+     gripper half as a JointTrajectory on /polyumi/target_gripper (fr3_gripper_bridge). The two
+     ride separate channels because a PoseArray cannot carry a width and because the Franka Hand
+     is action-only, so it needs a different execution cadence entirely — see
+     docs/crb-fr3-inference.md and docs/franka-inference-bringup.md ("Phase 2.5").
 
 Usage:
     ros2 run polyumi_ros2 policy_client_node
@@ -42,10 +46,17 @@ from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
 from rclpy.duration import Duration
 from rclpy.executors import MultiThreadedExecutor
 from rclpy.node import Node
-from sensor_msgs.msg import Image
+from sensor_msgs.msg import Image, JointState
 from tf2_ros import ConnectivityException, ExtrapolationException, LookupException  # type: ignore[attr-defined]
+from trajectory_msgs.msg import JointTrajectory, JointTrajectoryPoint
 
 from polyumi_ros2.camera_preproc import CAMERA0_RGB_INTERPOLATION
+from polyumi_ros2.gripper_map import policy_to_robot_width, robot_to_policy_width
+
+# Name used for the single "joint" in the gripper trajectory chunk. Deliberately NOT a real joint
+# name (the FR3's fingers are fr3_finger_joint1/2, each reporting half the aperture): the value we
+# publish is the full aperture, so naming it after a finger joint would invite a 2x error.
+GRIPPER_JOINT_NAME = 'fr3_gripper_width'
 
 
 class PolicyClientNode(Node):
@@ -126,6 +137,26 @@ class PolicyClientNode(Node):
         self.declare_parameter('latency.piezo_mic', 0.0)
         self.declare_parameter('latency.proprio', 0.0)
         self.declare_parameter('latency.arm_exec', 0.0)
+        # Delay from the hand's true aperture to its measurement appearing on the joint-state
+        # topic. Kept separate from latency.proprio because the gripper is a different device on a
+        # different link — UMI does the same (gripper_action_latency vs robot_action_latency).
+        # Unmeasured, like the rest; the topic jitters 24-100 ms, so the true value is not 0.
+        self.declare_parameter('latency.gripper', 0.0)
+        # --- Gripper ---
+        # Source for agent_pos[7]. The FR3 publishes each finger at HALF the aperture, so the two
+        # positions are summed; see docs/crb-fr3-inference.md ("Gripper interface").
+        self.declare_parameter('gripper_state_topic', '/fr3_gripper/joint_states')
+        # If true, a tick with no gripper state is skipped (as a failed TF lookup is). Off by
+        # default so setups without a hand — motion_only bringup, a bare arm — still run, feeding
+        # the closed width with a throttled warning rather than stalling the whole loop.
+        self.declare_parameter('require_gripper_state', False)
+        # Finger-tag separation with the gripper fully closed, subtracted to get jaw aperture.
+        # !!! NEVER MEASURED — it is gripper_calib.yaml's closed_mm, a value no code reads. !!!
+        # UMI measures its equivalent from a calibration video; see polyumi_ros2.gripper_map.
+        self.declare_parameter('gripper_offset_m', 0.005)
+        # Commanded widths clamp here. The FR3 hand reads ~0.0817 m fully open, but max_width is
+        # not published on any topic, so this is a constant rather than something we can read back.
+        self.declare_parameter('gripper_max_width_m', 0.08)
         # How far back (seconds) the EE-pose TF buffer retains history — must be >= the
         # largest latency being compensated for (see _lookup_agent_pos).
         self.declare_parameter('buffers.ee_pose_s', 1.0)
@@ -145,12 +176,17 @@ class PolicyClientNode(Node):
         self._steps_per_inference = self.get_parameter('steps_per_inference').get_parameter_value().integer_value
         control_hz = self.get_parameter('control_hz').get_parameter_value().double_value
         image_topic = self.get_parameter('image_topic').get_parameter_value().string_value
+        gripper_topic = self.get_parameter('gripper_state_topic').get_parameter_value().string_value
+        self._require_gripper_state = self.get_parameter('require_gripper_state').get_parameter_value().bool_value
+        self._gripper_offset_m = self.get_parameter('gripper_offset_m').get_parameter_value().double_value
+        self._gripper_max_width_m = self.get_parameter('gripper_max_width_m').get_parameter_value().double_value
         self._latency = {
             'gopro': self.get_parameter('latency.gopro').get_parameter_value().double_value,
             'finger_cam': self.get_parameter('latency.finger_cam').get_parameter_value().double_value,
             'piezo_mic': self.get_parameter('latency.piezo_mic').get_parameter_value().double_value,
             'proprio': self.get_parameter('latency.proprio').get_parameter_value().double_value,
             'arm_exec': self.get_parameter('latency.arm_exec').get_parameter_value().double_value,
+            'gripper': self.get_parameter('latency.gripper').get_parameter_value().double_value,
         }
         self._ee_pose_buffer_s = self.get_parameter('buffers.ee_pose_s').get_parameter_value().double_value
         self._validate_params(control_hz)
@@ -176,6 +212,14 @@ class PolicyClientNode(Node):
         self._latest_image: np.ndarray | None = None
         self._latest_image_stamp: rclpy.time.Time | None = None
         self._latest_image_lock = threading.Lock()
+        # Gripper aperture history, (stamp, width_m) oldest-first, for the same reason TF keeps a
+        # buffer: the width must be sampled at the *frame's* capture instant, not at tick time.
+        # tf2 does that interpolation for the pose; there's no equivalent for a plain topic, so we
+        # keep a short ring and interpolate by hand (see _gripper_width_at). Sized to cover
+        # ee_pose_s at the observed ~17 Hz with headroom, floored so a tiny buffer config can't
+        # leave us with a single sample and no interval to interpolate over.
+        self._gripper_buffer: deque = deque(maxlen=max(8, int(self._ee_pose_buffer_s * 40)))
+        self._gripper_lock = threading.Lock()
         # Reject a cached frame older than this at tick time; a frame older than this means the
         # capture pipeline stalled. The auto default (max_image_age_s <= 0) is two camera periods
         # at the 60 Hz v4l2 rate, floored at half a control period so a slow tick doesn't trip it;
@@ -198,16 +242,26 @@ class PolicyClientNode(Node):
         # goals across the rmw-major boundary. So when execution is enabled we just publish
         # the target EEF pose chunk (PoseArray); the NUC bridge subscribes and plans+executes
         # the whole chunk as one Cartesian path via its local move_group.
+        # The gripper rides a SEPARATE topic, not a field on the pose chunk: a PoseArray cannot
+        # carry a width, and the Franka Hand is action-only (no ros2_control interface, libfranka
+        # offers only blocking move/grasp), so it cannot be driven at the arm's cadence anyway.
+        # fr3_gripper_bridge on the NUC deadbands and rate-limits it into Move/Grasp goals.
         self._target_pub = None
+        self._gripper_pub = None
         if self._execute_motion:
             self._target_pub = self.create_publisher(PoseArray, '/polyumi/target_poses', 10)
+            self._gripper_pub = self.create_publisher(JointTrajectory, '/polyumi/target_gripper', 10)
 
         # Viz-only preview publisher (always on when publish_preview). Shows every commanded chunk
         # in Foxglove/RViz without moving the arm: the NUC bridge subscribes only to the execution
         # topic /polyumi/target_poses, never this one.
         self._preview_pub = None
+        self._gripper_preview_pub = None
         if self._publish_preview:
             self._preview_pub = self.create_publisher(PoseArray, '/polyumi/target_poses_preview', 10)
+            self._gripper_preview_pub = self.create_publisher(
+                JointTrajectory, '/polyumi/target_gripper_preview', 10
+            )
 
         # Episode-start /reset. The server needs the episode-start EEF pose for
         # robot0_eef_rot_axis_angle_wrt_start; sent once on the first full-buffer tick. The reset
@@ -217,6 +271,7 @@ class PolicyClientNode(Node):
 
         # Subscribers
         self.create_subscription(Image, image_topic, self._image_cb, 10)
+        self.create_subscription(JointState, gripper_topic, self._gripper_cb, 10)
 
         # Control timer — exclusive callback group ensures only one tick (and its
         # blocking POST) runs at a time; an in-flight tick causes the next one to
@@ -247,6 +302,11 @@ class PolicyClientNode(Node):
         self.get_logger().info(
             f'latency budget — measured observation age (capture→response) + '
             f'act={self._latency_act}s vs action_dt={self._action_dt}s'
+        )
+        gripper_missing = 'skip tick' if self._require_gripper_state else 'warn + use closed width'
+        self.get_logger().info(
+            f'gripper — state: {gripper_topic} (missing: {gripper_missing}), '
+            f'offset={self._gripper_offset_m}m (UNMEASURED), max_width={self._gripper_max_width_m}m'
         )
 
     def _validate_params(self, control_hz: float) -> None:
@@ -285,6 +345,10 @@ class PolicyClientNode(Node):
         for name, seconds in self._latency.items():
             if seconds < 0:
                 errors.append(f'latency.{name} must be >= 0, got {seconds}')
+        if self._gripper_offset_m < 0:
+            errors.append(f'gripper_offset_m must be >= 0, got {self._gripper_offset_m}')
+        if self._gripper_max_width_m <= 0:
+            errors.append(f'gripper_max_width_m must be > 0, got {self._gripper_max_width_m}')
         # The TF buffer must reach back at least as far as the instant we look poses up at,
         # or _lookup_agent_pos asks for a transform the buffer has already dropped.
         compensated = self._latency['gopro'] - self._latency['proprio']
@@ -323,6 +387,54 @@ class PolicyClientNode(Node):
             # camera period old before the tick even fires — and if the v4l2 pipeline stalls,
             # unboundedly older, with no way to notice. See _lookup_agent_pos.
             self._latest_image_stamp = rclpy.time.Time.from_msg(msg.header.stamp)
+
+    def _gripper_cb(self, msg: JointState) -> None:
+        """Cache the gripper aperture with its stamp, summing the two finger joints."""
+        if len(msg.position) < 2:
+            self._warn_throttled(
+                f'Ignoring gripper state with {len(msg.position)} position(s); expected 2 '
+                f'(names: {list(msg.name)})'
+            )
+            return
+        # Each FR3 finger reports HALF the aperture, so the full opening is their sum. Summing
+        # rather than doubling position[0] keeps this honest if the fingers are ever asymmetric.
+        width = float(msg.position[0] + msg.position[1])
+        with self._gripper_lock:
+            self._gripper_buffer.append((rclpy.time.Time.from_msg(msg.header.stamp), width))
+
+    def _gripper_width_at(self, target: rclpy.time.Time) -> float | None:
+        """
+        Linearly interpolate the cached gripper aperture to ``target``, or None if unavailable.
+
+        The same time-alignment discipline the TF lookup gets, done by hand because a plain topic
+        has no tf2-style interpolating buffer. Outside the cached span we hold the nearest endpoint
+        rather than extrapolating: the hand moves slowly relative to the ~60 ms sample interval, so
+        a held value is a far smaller error than a linear extrapolation off the end would be.
+
+        :param target: instant to sample the aperture at.
+        :returns: aperture in metres, or None if no gripper state has been received at all.
+        """
+        with self._gripper_lock:
+            samples = list(self._gripper_buffer)
+        if not samples:
+            return None
+
+        t_ns = target.nanoseconds
+        if t_ns <= samples[0][0].nanoseconds:
+            return samples[0][1]
+        if t_ns >= samples[-1][0].nanoseconds:
+            return samples[-1][1]
+
+        for (t0, w0), (t1, w1) in zip(samples, samples[1:]):
+            t0_ns, t1_ns = t0.nanoseconds, t1.nanoseconds
+            if t0_ns <= t_ns <= t1_ns:
+                if t1_ns == t0_ns:  # duplicate stamps — nothing to interpolate over
+                    return w1
+                alpha = (t_ns - t0_ns) / (t1_ns - t0_ns)
+                return w0 + alpha * (w1 - w0)
+        # Unreachable given the endpoint guards above, but a bad stamp ordering shouldn't crash
+        # the control loop — fall back to the freshest sample.
+        return samples[-1][1]
 
     # ------------------------------------------------------------------
     # Control loop
@@ -422,9 +534,11 @@ class PolicyClientNode(Node):
 
         tf2's Buffer interpolates (linear + slerp) between the two nearest cached transforms
         automatically; buffers.ee_pose_s sizes the buffer's cache_time so the lookup stays in
-        range.
+        range. The gripper width gets the same treatment via _gripper_width_at, hand-rolled
+        because a plain topic has no equivalent interpolating buffer.
 
         :param image_stamp: header stamp of the camera frame this pose will be paired with.
+        :returns: the 8-vector agent_pos, or None if the tick should be skipped.
         """
         # tf2 time=0 means "latest available" — used for the dry-run clock-skew workaround.
         target_time = rclpy.time.Time() if self._tf_use_latest else (
@@ -437,11 +551,47 @@ class PolicyClientNode(Node):
             self._warn_throttled(f'TF lookup failed: {e}')
             return None
 
+        gripper_width = self._gripper_width_policy_units(image_stamp)
+        if gripper_width is None:
+            return None  # warning already logged inside
+
         t = tf.transform.translation
         r = tf.transform.rotation
-        # gripper_width placeholder — replaced in Phase 2 with real joint state subscriber
-        gripper_width = 0.0
         return np.array([t.x, t.y, t.z, r.x, r.y, r.z, r.w, gripper_width], dtype=np.float64)
+
+    def _gripper_width_policy_units(self, image_stamp: rclpy.time.Time) -> float | None:
+        """
+        Sample the gripper aperture aligned to the frame, converted into the policy's units.
+
+        Time-aligned exactly as the pose is, with latency.gripper standing in for
+        latency.proprio — the hand is a separate device reporting on its own topic at its own
+        rate, which is why UMI also keeps the two constants apart.
+
+        :param image_stamp: header stamp of the camera frame this observation belongs to.
+        :returns: width in policy units (finger-tag separation), or None if the tick should be
+            skipped because require_gripper_state is set and no state has arrived.
+        """
+        target_time = rclpy.time.Time() if self._tf_use_latest else (
+            image_stamp - Duration(seconds=self._latency['gopro'])
+            + Duration(seconds=self._latency['gripper'])
+        )
+        width = self._gripper_width_at(target_time)
+        if width is None:
+            if self._require_gripper_state:
+                self._warn_throttled(
+                    'Dropped control tick: no gripper state received yet '
+                    '(require_gripper_state is set)'
+                )
+                return None
+            # Substituting the closed width is a lie to the policy, but a survivable one — it keeps
+            # arm-only bringup (motion_only, no hand) working. The startup banner says which mode
+            # is active so this isn't silent.
+            self._warn_throttled(
+                'No gripper state received yet; substituting closed width for agent_pos[7]. '
+                'Set require_gripper_state:=true to skip these ticks instead.'
+            )
+            return robot_to_policy_width(0.0, self._gripper_offset_m)
+        return robot_to_policy_width(width, self._gripper_offset_m)
 
     def _n_stale_actions(self, t_obs: rclpy.time.Time) -> int:
         """
@@ -517,6 +667,8 @@ class PolicyClientNode(Node):
         # stale. The NUC bridge never subscribes to this topic, so nothing moves.
         if self._preview_pub is not None:
             self._preview_pub.publish(self._actions_to_pose_array(actions))
+        if self._gripper_preview_pub is not None:
+            self._gripper_preview_pub.publish(self._actions_to_gripper_trajectory(actions))
 
         # Drop the leading actions that refer to instants already elapsed by the time the arm
         # can act on them, so execution starts from the first still-future waypoint.
@@ -534,18 +686,26 @@ class PolicyClientNode(Node):
             return
 
         first = actions[0]
+        # Log the width in both spaces: policy units are what the model emitted, robot units are
+        # what the hand will be commanded. A surprising gap between them is the offset being wrong.
+        grip_robot = policy_to_robot_width(
+            float(first[7]), self._gripper_offset_m, self._gripper_max_width_m
+        )
         self.get_logger().info(
             f'action chunk n={len(actions)} (dropped {n_stale}/{n_received} stale, '
             f'inference={latency_inference * 1000:.0f}ms) first: x={first[0]:.4f} y={first[1]:.4f} '
-            f'z={first[2]:.4f} grip={first[7]:.3f}'
+            f'z={first[2]:.4f} grip={first[7]:.3f}→{grip_robot:.3f}m'
         )
 
         # Phase 2: publish the whole action chunk for the NUC bridge to plan+execute as one
         # Cartesian path (receding-horizon control). Non-blocking (unlike a direct MoveIt
         # call): the NUC bridge does its own skip-while-busy, so at worst it drops chunks
-        # that arrive mid-motion. Gripper (action[7]) is deferred; only xyz+quat is published.
+        # that arrive mid-motion. The gripper half goes out on its own topic, from the same
+        # (already stale-dropped) action list so the two chunks stay index-aligned.
         if self._target_pub is not None:
             self._target_pub.publish(self._actions_to_pose_array(actions))
+        if self._gripper_pub is not None:
+            self._gripper_pub.publish(self._actions_to_gripper_trajectory(actions))
 
     def _actions_to_pose_array(self, actions) -> PoseArray:
         """Build a PoseArray in base_frame from a list of 8-vector actions [x,y,z,qx,qy,qz,qw,grip]."""
@@ -565,6 +725,30 @@ class PolicyClientNode(Node):
         msg.header.stamp = self.get_clock().now().to_msg()
         msg.header.frame_id = self._base_frame
         msg.poses = poses
+        return msg
+
+    def _actions_to_gripper_trajectory(self, actions) -> JointTrajectory:
+        """
+        Build the gripper half of an action chunk as a timed single-DOF trajectory.
+
+        Carries per-point ``time_from_start`` (unlike the pose PoseArray, which has no timing yet)
+        so the NUC bridge can pick a lead waypoint and derive a move speed from it, rather than
+        commanding every width at one fixed speed. The widths are converted to robot jaw aperture
+        here so the bridge stays free of calibration — see polyumi_ros2.gripper_map.
+
+        :param actions: 8-vector actions [x,y,z,qx,qy,qz,qw,grip], grip in policy units.
+        """
+        msg = JointTrajectory()
+        msg.header.stamp = self.get_clock().now().to_msg()
+        msg.header.frame_id = self._base_frame
+        msg.joint_names = [GRIPPER_JOINT_NAME]
+        for i, action in enumerate(actions):
+            point = JointTrajectoryPoint()
+            point.positions = [
+                policy_to_robot_width(float(action[7]), self._gripper_offset_m, self._gripper_max_width_m)
+            ]
+            point.time_from_start = Duration(seconds=i * self._action_dt).to_msg()
+            msg.points.append(point)
         return msg
 
     def _warn_throttled(self, msg: str) -> None:

--- a/ros2_ws/src/polyumi_ros2/polyumi_ros2/policy_client_node.py
+++ b/ros2_ws/src/polyumi_ros2/polyumi_ros2/policy_client_node.py
@@ -150,6 +150,13 @@ class PolicyClientNode(Node):
         # default so setups without a hand — motion_only bringup, a bare arm — still run, feeding
         # the closed width with a throttled warning rather than stalling the whole loop.
         self.declare_parameter('require_gripper_state', False)
+        # Reject a cached gripper sample older than this at lookup time. The gripper is the only
+        # observation channel that can go stale *silently*: a dead camera trips max_image_age_s
+        # and dead TF raises ExtrapolationException, but _gripper_width_at just keeps holding its
+        # last sample forever, feeding the policy a frozen width with no complaint. 0.5s is ~5x
+        # the worst observed publish interval (the topic jitters 24-100ms) so ordinary jitter
+        # cannot trip it, and well short of the ~2.3s the buffer can hold. <= 0 disables the check.
+        self.declare_parameter('max_gripper_age_s', 0.5)
         # Finger-tag separation with the gripper fully closed, subtracted to get jaw aperture.
         # !!! NEVER MEASURED — it is gripper_calib.yaml's closed_mm, a value no code reads. !!!
         # UMI measures its equivalent from a calibration video; see polyumi_ros2.gripper_map.
@@ -178,6 +185,7 @@ class PolicyClientNode(Node):
         image_topic = self.get_parameter('image_topic').get_parameter_value().string_value
         gripper_topic = self.get_parameter('gripper_state_topic').get_parameter_value().string_value
         self._require_gripper_state = self.get_parameter('require_gripper_state').get_parameter_value().bool_value
+        self._max_gripper_age_s = self.get_parameter('max_gripper_age_s').get_parameter_value().double_value
         self._gripper_offset_m = self.get_parameter('gripper_offset_m').get_parameter_value().double_value
         self._gripper_max_width_m = self.get_parameter('gripper_max_width_m').get_parameter_value().double_value
         self._latency = {
@@ -304,8 +312,11 @@ class PolicyClientNode(Node):
             f'act={self._latency_act}s vs action_dt={self._action_dt}s'
         )
         gripper_missing = 'skip tick' if self._require_gripper_state else 'warn + use closed width'
+        gripper_stale = 'skip tick' if self._require_gripper_state else 'warn + hold last width'
+        max_age = f'{self._max_gripper_age_s}s' if self._max_gripper_age_s > 0 else 'disabled'
         self.get_logger().info(
-            f'gripper — state: {gripper_topic} (missing: {gripper_missing}), '
+            f'gripper — state: {gripper_topic} (missing: {gripper_missing}; '
+            f'stale > {max_age}: {gripper_stale}), '
             f'offset={self._gripper_offset_m}m (UNMEASURED), max_width={self._gripper_max_width_m}m'
         )
 
@@ -402,7 +413,7 @@ class PolicyClientNode(Node):
         with self._gripper_lock:
             self._gripper_buffer.append((rclpy.time.Time.from_msg(msg.header.stamp), width))
 
-    def _gripper_width_at(self, target: rclpy.time.Time) -> float | None:
+    def _gripper_width_at(self, target: rclpy.time.Time | None) -> float | None:
         """
         Linearly interpolate the cached gripper aperture to ``target``, or None if unavailable.
 
@@ -411,13 +422,18 @@ class PolicyClientNode(Node):
         rather than extrapolating: the hand moves slowly relative to the ~60 ms sample interval, so
         a held value is a far smaller error than a linear extrapolation off the end would be.
 
-        :param target: instant to sample the aperture at.
+        :param target: instant to sample the aperture at, or None for "latest available".
+            Note this is deliberately **not** tf2's convention, where a zero ``Time()`` means
+            latest — here a zero stamp is just an instant before every sample, and would return
+            the *oldest* one. Callers with a tf2-style sentinel must translate it to None.
         :returns: aperture in metres, or None if no gripper state has been received at all.
         """
         with self._gripper_lock:
             samples = list(self._gripper_buffer)
         if not samples:
             return None
+        if target is None:
+            return samples[-1][1]
 
         t_ns = target.nanoseconds
         if t_ns <= samples[0][0].nanoseconds:
@@ -435,6 +451,20 @@ class PolicyClientNode(Node):
         # Unreachable given the endpoint guards above, but a bad stamp ordering shouldn't crash
         # the control loop — fall back to the freshest sample.
         return samples[-1][1]
+
+    def _newest_gripper_age_s(self) -> float | None:
+        """
+        Seconds between now and the freshest cached gripper sample, or None if there are none.
+
+        Measured against the node clock rather than against the sample spacing, so a topic that
+        stops entirely — the failure _gripper_width_at cannot see, since holding an endpoint looks
+        identical to a slow publisher — grows this without bound.
+        """
+        with self._gripper_lock:
+            if not self._gripper_buffer:
+                return None
+            newest = self._gripper_buffer[-1][0]
+        return (self.get_clock().now() - newest).nanoseconds * 1e-9
 
     # ------------------------------------------------------------------
     # Control loop
@@ -569,9 +599,11 @@ class PolicyClientNode(Node):
 
         :param image_stamp: header stamp of the camera frame this observation belongs to.
         :returns: width in policy units (finger-tag separation), or None if the tick should be
-            skipped because require_gripper_state is set and no state has arrived.
+            skipped because require_gripper_state is set and no usable state is available.
         """
-        target_time = rclpy.time.Time() if self._tf_use_latest else (
+        # None (not a zero Time()) is this buffer's "latest available" sentinel — tf2's zero-stamp
+        # convention does not carry over, and passing it through would return the OLDEST sample.
+        target_time = None if self._tf_use_latest else (
             image_stamp - Duration(seconds=self._latency['gopro'])
             + Duration(seconds=self._latency['gripper'])
         )
@@ -591,6 +623,27 @@ class PolicyClientNode(Node):
                 'Set require_gripper_state:=true to skip these ticks instead.'
             )
             return robot_to_policy_width(0.0, self._gripper_offset_m)
+
+        # A topic that stops publishing is invisible to _gripper_width_at — it just keeps holding
+        # its newest sample — so the age is checked explicitly, as the camera path does. Skipped
+        # under tf_use_latest, which exists precisely because the stamps are known to be skewed
+        # against this clock and would false-trip it.
+        age_s = self._newest_gripper_age_s()
+        if not self._tf_use_latest and self._max_gripper_age_s > 0 and age_s is not None \
+                and age_s > self._max_gripper_age_s:
+            if self._require_gripper_state:
+                self._warn_throttled(
+                    f'Dropped control tick: newest gripper state is {age_s * 1e3:.0f} ms old '
+                    f'(limit {self._max_gripper_age_s * 1e3:.0f} ms) — has the gripper topic died?'
+                )
+                return None
+            # Holding the last known width beats substituting closed: if the hand stopped
+            # reporting mid-grasp, "closed" is a bigger lie than "still where we last saw it".
+            self._warn_throttled(
+                f'Newest gripper state is {age_s * 1e3:.0f} ms old '
+                f'(limit {self._max_gripper_age_s * 1e3:.0f} ms) — has the gripper topic died? '
+                'Holding the last known width for agent_pos[7].'
+            )
         return robot_to_policy_width(width, self._gripper_offset_m)
 
     def _n_stale_actions(self, t_obs: rclpy.time.Time) -> int:

--- a/ros2_ws/src/polyumi_ros2/test/test_gripper_map.py
+++ b/ros2_ws/src/polyumi_ros2/test/test_gripper_map.py
@@ -1,0 +1,74 @@
+"""
+Tests for the policy<->robot gripper width conversion.
+
+The conversion is two lines of arithmetic, but it sits on a path where being wrong is invisible:
+a bad offset just commands a systematically-too-open or too-closed hand, and a bad clamp just
+saturates. Neither raises. These pin the direction of the offset (the sign is the easy thing to
+flip) and the clamping behaviour.
+"""
+
+import pytest
+
+from polyumi_ros2.gripper_map import policy_to_robot_width, robot_to_policy_width
+
+OFFSET = 0.005
+MAX_WIDTH = 0.08
+
+
+def test_offset_is_subtracted_going_to_the_robot():
+    """A closed handheld gripper (tags still separated by the offset) maps to a closed hand."""
+    assert policy_to_robot_width(OFFSET, OFFSET, MAX_WIDTH) == pytest.approx(0.0)
+
+
+def test_offset_is_added_coming_from_the_robot():
+    """A closed hand reads back as the offset, i.e. what the training data calls 'closed'."""
+    assert robot_to_policy_width(0.0, OFFSET) == pytest.approx(OFFSET)
+
+
+def test_round_trip_within_range_is_identity():
+    """Converting out and back changes nothing while the value stays in the robot's range."""
+    for policy_width in (0.005, 0.02, 0.05, 0.085):
+        robot = policy_to_robot_width(policy_width, OFFSET, MAX_WIDTH)
+        assert robot_to_policy_width(robot, OFFSET) == pytest.approx(policy_width)
+
+
+def test_slope_is_one():
+    """
+    The map is a pure offset, not a rescale.
+
+    This mirrors UMI: get_gripper_calibration_interpolator computes
+    aruco_actual_width - aruco_min_width, and the dataset plan passes the same array as both of
+    its arguments, so despite the interp1d machinery there is no gain term. A future change that
+    introduces scaling should have to update this test deliberately.
+    """
+    delta = 0.01
+    low = policy_to_robot_width(0.02, OFFSET, MAX_WIDTH)
+    high = policy_to_robot_width(0.02 + delta, OFFSET, MAX_WIDTH)
+    assert high - low == pytest.approx(delta)
+
+
+def test_clamps_at_the_robot_maximum():
+    """The handheld gripper opens wider than the hand, so over-wide commands saturate."""
+    assert policy_to_robot_width(0.5, OFFSET, MAX_WIDTH) == pytest.approx(MAX_WIDTH)
+
+
+def test_clamps_at_zero():
+    """A width below the offset would imply a negative aperture; it floors at closed instead."""
+    assert policy_to_robot_width(0.0, OFFSET, MAX_WIDTH) == pytest.approx(0.0)
+    assert policy_to_robot_width(-1.0, OFFSET, MAX_WIDTH) == pytest.approx(0.0)
+
+
+def test_observation_direction_is_not_clamped():
+    """
+    An out-of-range *measurement* passes through unclamped, on purpose.
+
+    Clamping the observation would hide a miscalibrated offset from both the policy and whoever
+    is reading the logs; the robot's actual aperture is real information either way.
+    """
+    assert robot_to_policy_width(0.5, OFFSET) == pytest.approx(0.505)
+
+
+def test_zero_offset_is_a_passthrough():
+    """With no offset configured the conversion degrades to a plain clamp."""
+    assert policy_to_robot_width(0.03, 0.0, MAX_WIDTH) == pytest.approx(0.03)
+    assert robot_to_policy_width(0.03, 0.0) == pytest.approx(0.03)

--- a/ros2_ws/src/polyumi_ros2/test/test_policy_client_node.py
+++ b/ros2_ws/src/polyumi_ros2/test/test_policy_client_node.py
@@ -529,6 +529,77 @@ def test_malformed_gripper_state_is_ignored(make_node):
     assert node._gripper_width_at(_t(1.0)) is None
 
 
+def test_tf_use_latest_takes_the_newest_gripper_sample(make_node):
+    """
+    Under tf_use_latest the gripper reads the NEWEST sample, not the oldest.
+
+    tf2 spells "latest available" as a zero ``Time()``, but this buffer is hand-rolled and a zero
+    stamp is simply an instant before every sample — passing the tf2 sentinel straight through
+    returns ``samples[0]``, i.e. the oldest entry, which at the buffer's depth is seconds stale.
+    A dry run is exactly where someone would be watching whether the width tracks, so it has to
+    be the fresh end.
+    """
+    node = make_node(tf_use_latest=True, gripper_offset_m=0.0)
+    for stamp, width in ((1.0, 0.01), (1.1, 0.05), (1.2, 0.08)):
+        _push_gripper(node, stamp, width)
+
+    assert node._gripper_width_at(None) == pytest.approx(0.08)
+    assert node._gripper_width_policy_units(image_stamp=_t(1.2)) == pytest.approx(0.08)
+
+
+def test_stale_gripper_state_holds_the_last_width_and_warns(make_node):
+    """
+    A gripper topic that *stops* is caught by age, and the last width is held rather than zeroed.
+
+    _gripper_width_at cannot see this failure — holding its newest endpoint looks identical to a
+    slow publisher — so without the age check the policy is fed a frozen width indefinitely and
+    in silence. Holding beats substituting closed: if the hand stopped reporting mid-grasp,
+    "closed" is the bigger lie.
+    """
+    node = make_node(gripper_offset_m=0.0, max_gripper_age_s=0.5, **{'latency.gopro': 0.0})
+    _push_gripper(node, 1.0, 0.06)
+
+    with patch.object(node, 'get_clock', return_value=_FakeClock(_t(3.0))), \
+            patch.object(node, '_warn_throttled') as warn:
+        width = node._gripper_width_policy_units(image_stamp=_t(3.0))
+
+    assert width == pytest.approx(0.06)
+    assert 'gripper topic died' in warn.call_args[0][0]
+
+
+def test_stale_gripper_state_skips_the_tick_when_required(make_node):
+    """With require_gripper_state, a stale width drops the tick like a missing one."""
+    node = make_node(require_gripper_state=True, max_gripper_age_s=0.5, **{'latency.gopro': 0.0})
+    _push_gripper(node, 1.0, 0.06)
+
+    with patch.object(node, 'get_clock', return_value=_FakeClock(_t(3.0))):
+        assert node._gripper_width_policy_units(image_stamp=_t(3.0)) is None
+
+
+def test_fresh_gripper_state_is_not_treated_as_stale(make_node):
+    """A width inside the age limit passes even under require_gripper_state."""
+    node = make_node(
+        require_gripper_state=True, gripper_offset_m=0.0, max_gripper_age_s=0.5,
+        **{'latency.gopro': 0.0},
+    )
+    _push_gripper(node, 1.0, 0.06)
+
+    with patch.object(node, 'get_clock', return_value=_FakeClock(_t(1.2))):
+        assert node._gripper_width_policy_units(image_stamp=_t(1.0)) == pytest.approx(0.06)
+
+
+def test_gripper_age_check_can_be_disabled(make_node):
+    """max_gripper_age_s <= 0 turns the check off, for setups with an odd clock or rate."""
+    node = make_node(
+        require_gripper_state=True, gripper_offset_m=0.0, max_gripper_age_s=0.0,
+        **{'latency.gopro': 0.0},
+    )
+    _push_gripper(node, 1.0, 0.06)
+
+    with patch.object(node, 'get_clock', return_value=_FakeClock(_t(100.0))):
+        assert node._gripper_width_policy_units(image_stamp=_t(100.0)) == pytest.approx(0.06)
+
+
 # ----------------------------------------------------------------------
 # Gripper — command chunk
 # ----------------------------------------------------------------------

--- a/ros2_ws/src/polyumi_ros2/test/test_policy_client_node.py
+++ b/ros2_ws/src/polyumi_ros2/test/test_policy_client_node.py
@@ -17,6 +17,7 @@ from geometry_msgs.msg import TransformStamped
 from rclpy.clock import ClockType
 from rclpy.parameter import Parameter
 from rclpy.time import Time
+from sensor_msgs.msg import JointState
 
 from polyumi_ros2.policy_client_node import PolicyClientNode
 
@@ -411,3 +412,198 @@ def test_tf_use_latest_ignores_stamp(make_node):
     agent_pos = node._lookup_agent_pos(image_stamp=_t(0.1))
     assert agent_pos is not None
     assert agent_pos[0] == pytest.approx(1.4, abs=1e-6)
+
+
+# ----------------------------------------------------------------------
+# Gripper — observation
+# ----------------------------------------------------------------------
+
+
+def _push_gripper(node, stamp_s: float, width_m: float) -> None:
+    """Feed one gripper joint state, split across the two fingers as the FR3 reports it."""
+    msg = JointState()
+    msg.header.stamp = _t(stamp_s).to_msg()
+    msg.name = ['fr3_finger_joint1', 'fr3_finger_joint2']
+    msg.position = [width_m / 2.0, width_m / 2.0]
+    node._gripper_cb(msg)
+
+
+def test_gripper_width_sums_the_two_finger_joints(make_node):
+    """
+    Aperture is the SUM of the finger positions, each of which is half the opening.
+
+    Reading position[0] alone (or the wrong joint) would halve every width the policy sees,
+    which is exactly the kind of error that looks plausible in a log.
+    """
+    node = make_node(gripper_offset_m=0.0, **{'latency.gopro': 0.0, 'latency.gripper': 0.0})
+    _push_gripper(node, 1.0, 0.06)
+
+    assert node._gripper_width_at(_t(1.0)) == pytest.approx(0.06)
+
+
+def test_gripper_width_lands_in_agent_pos_index_7(make_node):
+    """The measured aperture reaches agent_pos[7], converted into policy units."""
+    node = make_node(
+        gripper_offset_m=0.005, **{'latency.gopro': 0.0, 'latency.proprio': 0.0, 'latency.gripper': 0.0}
+    )
+    _push_ramp_tf(node)
+    _push_gripper(node, 1.0, 0.06)
+
+    agent_pos = node._lookup_agent_pos(image_stamp=_t(1.0))
+
+    assert agent_pos is not None
+    assert agent_pos[7] == pytest.approx(0.065)  # 0.06 aperture + 0.005 offset
+
+
+def test_gripper_width_interpolates_to_the_capture_instant(make_node):
+    """
+    The width is sampled at the frame's capture instant, like the pose — not at tick time.
+
+    Encoding time into width (width == timestamp) makes the returned value a direct readout of
+    which instant was queried, the same trick _push_ramp_tf uses for the pose.
+    """
+    node = make_node(gripper_offset_m=0.0, **{'latency.gopro': 0.05, 'latency.gripper': 0.0})
+    for t in (0.8, 0.9, 1.0):
+        _push_gripper(node, t, t)
+
+    # 1.0 - 0.05 = 0.95, i.e. between the 0.9 and 1.0 samples rather than snapped to either.
+    assert node._gripper_width_at(_t(0.95)) == pytest.approx(0.95, abs=1e-6)
+    assert node._gripper_width_policy_units(image_stamp=_t(1.0)) == pytest.approx(0.95, abs=1e-6)
+
+
+def test_gripper_latency_shifts_the_query_forward(make_node):
+    """latency.gripper moves the query the same direction proprio does for the pose."""
+    node = make_node(gripper_offset_m=0.0, **{'latency.gopro': 0.05, 'latency.gripper': 0.01})
+    for t in (0.8, 0.9, 1.0):
+        _push_gripper(node, t, t)
+
+    # 1.0 - 0.05 + 0.01 = 0.96
+    assert node._gripper_width_policy_units(image_stamp=_t(1.0)) == pytest.approx(0.96, abs=1e-6)
+
+
+def test_gripper_width_holds_endpoints_rather_than_extrapolating(make_node):
+    """Outside the cached span the nearest sample is held; extrapolation would invent motion."""
+    node = make_node(gripper_offset_m=0.0)
+    _push_gripper(node, 1.0, 0.04)
+    _push_gripper(node, 1.1, 0.05)
+
+    assert node._gripper_width_at(_t(0.5)) == pytest.approx(0.04)
+    assert node._gripper_width_at(_t(5.0)) == pytest.approx(0.05)
+
+
+def test_missing_gripper_state_falls_back_to_closed(make_node):
+    """
+    With no gripper state the tick still runs, substituting the closed width.
+
+    This is what keeps arm-only bringup (motion_only, no hand attached) working rather than
+    stalling the whole control loop on a device that isn't there.
+    """
+    node = make_node(gripper_offset_m=0.005, **{'latency.gopro': 0.0, 'latency.proprio': 0.0})
+    _push_ramp_tf(node)
+
+    agent_pos = node._lookup_agent_pos(image_stamp=_t(1.0))
+
+    assert agent_pos is not None
+    assert agent_pos[7] == pytest.approx(0.005)  # closed aperture (0.0) in policy units
+
+
+def test_require_gripper_state_skips_the_tick_instead(make_node):
+    """With require_gripper_state, a missing width drops the tick like a failed TF lookup."""
+    node = make_node(
+        require_gripper_state=True, **{'latency.gopro': 0.0, 'latency.proprio': 0.0}
+    )
+    _push_ramp_tf(node)  # pose is available; only the gripper is missing
+
+    assert node._lookup_agent_pos(image_stamp=_t(1.0)) is None
+
+
+def test_malformed_gripper_state_is_ignored(make_node):
+    """A joint state with too few positions is dropped rather than crashing the callback."""
+    node = make_node()
+    msg = JointState()
+    msg.header.stamp = _t(1.0).to_msg()
+    msg.name = ['fr3_finger_joint1']
+    msg.position = [0.02]
+    node._gripper_cb(msg)
+
+    assert node._gripper_width_at(_t(1.0)) is None
+
+
+# ----------------------------------------------------------------------
+# Gripper — command chunk
+# ----------------------------------------------------------------------
+
+
+def _actions_with_grip(widths):
+    """Build 8-vector actions whose only interesting component is the gripper width."""
+    return [[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, w] for w in widths]
+
+
+def test_gripper_trajectory_converts_to_robot_units(make_node):
+    """
+    Widths are converted to jaw aperture here, so the NUC bridge needs no calibration.
+
+    Keeping the conversion on this side means one place holds the offset, and the bridge can
+    stay a dumb executor of the metres it is handed.
+    """
+    node = make_node(control_hz=10.0, gripper_offset_m=0.005, gripper_max_width_m=0.08)
+
+    msg = node._actions_to_gripper_trajectory(_actions_with_grip([0.005, 0.025, 0.5]))
+
+    assert [p.positions[0] for p in msg.points] == pytest.approx([0.0, 0.02, 0.08])
+
+
+def test_gripper_trajectory_carries_chunk_timing(make_node):
+    """
+    Each point is stamped with its offset into the chunk, spaced by the control period.
+
+    The bridge uses this to size its move speed, which is the whole reason the gripper chunk is
+    a JointTrajectory rather than a bare array of widths.
+    """
+    node = make_node(control_hz=10.0)
+
+    msg = node._actions_to_gripper_trajectory(_actions_with_grip([0.02] * 3))
+
+    times = [p.time_from_start.sec + p.time_from_start.nanosec * 1e-9 for p in msg.points]
+    assert times == pytest.approx([0.0, 0.1, 0.2])
+    assert msg.joint_names == ['fr3_gripper_width']
+
+
+def test_gripper_and_pose_chunks_stay_index_aligned(make_node):
+    """
+    Both execution topics get the same number of waypoints, after the same stale-drop.
+
+    The two chunks are separate messages describing one action list, so a length mismatch would
+    silently pair each pose with the wrong width.
+    """
+    node = make_node(control_hz=10.0, execute_motion=True, publish_preview=False)
+    actions = _actions_with_grip([0.01 * i for i in range(8)])
+    now = _t(100.0)
+    t_obs = _t(99.75)  # partially stale: some leading actions get dropped
+
+    with patch.object(node, '_http_post_json', return_value={'actions': actions}), \
+            patch.object(node, 'get_clock', return_value=_FakeClock(now)), \
+            patch.object(node._target_pub, 'publish') as pose_pub, \
+            patch.object(node._gripper_pub, 'publish') as grip_pub:
+        node._post_and_act(payload={}, t_obs=t_obs)
+
+    pose_msg = pose_pub.call_args[0][0]
+    grip_msg = grip_pub.call_args[0][0]
+    assert 0 < len(pose_msg.poses) < 8  # the drop actually happened
+    assert len(grip_msg.points) == len(pose_msg.poses)
+
+
+def test_gripper_preview_publishes_full_chunk(make_node):
+    """The gripper preview mirrors the pose preview: full chunk, no execution publisher."""
+    node = make_node(control_hz=10.0, publish_preview=True)  # execute_motion defaults False
+    assert node._gripper_pub is None
+
+    actions = _actions_with_grip([0.02] * 8)
+    now = _t(100.0)
+    with patch.object(node, '_http_post_json', return_value={'actions': actions}), \
+            patch.object(node, 'get_clock', return_value=_FakeClock(now)), \
+            patch.object(node._gripper_preview_pub, 'publish') as grip_preview:
+        node._post_and_act(payload={}, t_obs=_t(98.0))  # fully stale
+
+    grip_preview.assert_called_once()
+    assert len(grip_preview.call_args[0][0].points) == 8


### PR DESCRIPTION
Added ability to control the gripper in real time from inference server.
Validated using dummy server AND actual model inference server. 
Also, tried out a newly trained checkpoint off the v1 red trapezoid dataset. Unfortunately doesn't perform; it's unclear what link in this big chain is broken at the moment. But with execution speed set at 0.2, the policy actually moves the arm pretty smoothly. 

I want to merge in this stuff because it's clear the gripper control side is working fine

(though it is a bit erratic when running at 0.8 speed with the dummy server. jerky motion in both arm and fingers due to blocking action calls).